### PR TITLE
HotFix: View in Explorer link navigates to transactions explorer

### DIFF
--- a/src/components/common/ConnectButton/ConnectButton.tsx
+++ b/src/components/common/ConnectButton/ConnectButton.tsx
@@ -81,7 +81,7 @@ const ConnectButton = ({ className }: Props) => {
   }, [bech32Address, isConnected]);
 
   const handleExplorerClick = () => {
-    openNewTab("https://app.fuel.network/");
+    openNewTab(`https://app.fuel.network/account/${bech32Address}/transactions`);
   };
 
   const handleHistoryOpen = () => {

--- a/src/components/common/ConnectButton/DisconnectMobile.tsx
+++ b/src/components/common/ConnectButton/DisconnectMobile.tsx
@@ -61,7 +61,7 @@ const DisconnectMobile = ({ className }: Props) => {
   }
 
   const handleExplorerClick = () => {
-    openNewTab("https://app.fuel.network/");
+    openNewTab(`https://app.fuel.network/account/${bech32Address}/transactions`);
   };
 
   const handleCopy = useCallback(async () => {


### PR DESCRIPTION
link: `https://app.fuel.network/account/${bech32Address}/transactions`