### PR TITLE
HotFix: landing page connect button

### DIFF
--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -91,7 +91,11 @@ const Header = ({ isHomePage }: Props) => {
           {!isHomePage && <ConnectButton className={styles.launchAppButton} />}
           {isHomePage && (
             <div className={styles.launchAppArea}>
-              <LaunchAppButton className={styles.launchAppButton} />
+              {isConnected ? (
+                <ConnectButton className={styles.launchAppButton} />
+              ) : (
+                <LaunchAppButton className={styles.launchAppButton} />
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
On the landing page, when the wallet is connected, the Connect button is rendered instead of the Launch App button.