### PR TITLE
chore: upgrading `fuels` to `0.96.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@fuels/connectors": "0.33.0",
-    "@fuels/react": "0.33.0",
+    "@fuels/connectors": "0.35.0",
+    "@fuels/react": "0.35.0",
     "@tanstack/react-query": "^5.50.1",
     "clsx": "^2.1.1",
     "firebase": "^10.12.4",
-    "fuels": "^0.95.0",
+    "fuels": "^0.96.0",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.0",
     "mira-dex-ts": "^1.0.26",


### PR DESCRIPTION
# Summary

Upgrading `fuels` to `0.96.0`.

```
LICENSE:
The Fuel Support team submits this PR to help you use the fuel SDKs. It is provided "as is" 
and without warranty for any purpose. We are not participants in the project at hand. 
All the rights of this code are reserved to the authors of this repository.
```