### PR TITLE
chore: upgrading `fuels` to `0.96.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "mira-amm",
       "version": "0.1.0",
       "dependencies": {
-        "@fuels/connectors": "0.35.0",
-        "@fuels/react": "0.35.0",
+        "@fuels/connectors": "0.35.1",
+        "@fuels/react": "0.35.1",
         "@tanstack/react-query": "^5.50.1",
         "clsx": "^2.1.1",
-        "fuels": "^0.96.0",
+        "fuels": "^0.96.1",
         "graphql": "^16.9.0",
         "graphql-request": "^7.1.0",
         "mira-dex-ts": "^1.0.27",
@@ -2786,17 +2786,17 @@
       }
     },
     "node_modules/@fuel-ts/abi-coder": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/abi-coder/-/abi-coder-0.96.0.tgz",
-      "integrity": "sha512-8l1O0jkSHHTg7vE7Bq6lIEICskE/hSeyhB+q3ppxbqnr7KNObiPuTxrOK7TDrGUXsxOXk5g65hN1f//aS9HHSA==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/abi-coder/-/abi-coder-0.96.1.tgz",
+      "integrity": "sha512-czJxFPirhSO6ayshu9Cr5AmED/IprQ8h1igwlcSHFr5jR+l46bLdlsXsWiUwe7vyvZCpOnxkN/XZYkmQyNxKNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/crypto": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/hasher": "^0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/utils": "0.96.0",
+        "@fuel-ts/crypto": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/hasher": "^0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/utils": "0.96.1",
         "type-fest": "^4.26.1"
       },
       "engines": {
@@ -2816,15 +2816,15 @@
       }
     },
     "node_modules/@fuel-ts/abi-typegen": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/abi-typegen/-/abi-typegen-0.96.0.tgz",
-      "integrity": "sha512-EFWUMa+aKMvgZSPc7we0exrfp9qKbw6E+CSlGUYy1JZBZwaaBHsRrQ2EGL9d9q6doWD4VamV+y9Fgj6MYeuGkQ==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/abi-typegen/-/abi-typegen-0.96.1.tgz",
+      "integrity": "sha512-vRJnAQ9sxkKuUQ2fkxntPm/679grxgwSf54O7vgDeXuXqQx/4XeylpExjH0/nZzEM5al+muw4rg9WwmKulkcZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/interfaces": "^0.96.0",
-        "@fuel-ts/utils": "0.96.0",
-        "@fuel-ts/versions": "0.96.0",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/interfaces": "^0.96.1",
+        "@fuel-ts/utils": "0.96.1",
+        "@fuel-ts/versions": "0.96.1",
         "commander": "12.1.0",
         "glob": "^10.4.5",
         "handlebars": "^4.7.8",
@@ -2929,22 +2929,22 @@
       }
     },
     "node_modules/@fuel-ts/account": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/account/-/account-0.96.0.tgz",
-      "integrity": "sha512-zpcpf4NR9vMcHoAfpXgp7SAqHf8hmRgtWGuLReqQnqcJz2g14pF7aIue+bF6kLuBf3o0YrINMPkuFlzLBgxBFQ==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/account/-/account-0.96.1.tgz",
+      "integrity": "sha512-i9InTebg3/buKXNJZpKBhxGMBC3MKpk905Uiv2CvTmldyPVgnZV/jY/b63jlfdEWyP5yVkr5/tzo7QaPKpfnMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/abi-coder": "0.96.0",
-        "@fuel-ts/address": "0.96.0",
-        "@fuel-ts/crypto": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/hasher": "0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/merkle": "0.96.0",
-        "@fuel-ts/transactions": "0.96.0",
-        "@fuel-ts/utils": "0.96.0",
-        "@fuel-ts/versions": "0.96.0",
+        "@fuel-ts/abi-coder": "0.96.1",
+        "@fuel-ts/address": "0.96.1",
+        "@fuel-ts/crypto": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/hasher": "0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/merkle": "0.96.1",
+        "@fuel-ts/transactions": "0.96.1",
+        "@fuel-ts/utils": "0.96.1",
+        "@fuel-ts/versions": "0.96.1",
         "@fuels/vm-asm": "0.58.0",
         "@noble/curves": "^1.6.0",
         "events": "^3.3.0",
@@ -3009,15 +3009,15 @@
       }
     },
     "node_modules/@fuel-ts/address": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/address/-/address-0.96.0.tgz",
-      "integrity": "sha512-IU7bVyqjQnHJmnqApbEkAGwvEwImc/QoCCciw3KhkiV4OP/LneOZvOtLKMAWkorBcNeAnw6U1sIRIY8jYHGIYw==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/address/-/address-0.96.1.tgz",
+      "integrity": "sha512-PCuC8oojoWLhh0+boitaP90/Z3iSfEXZR8v1JCEfoLZIkvCq6EGKtiY0KvcNkPozHOHmmT34w/1CS6qHOoCBNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/crypto": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/utils": "^0.96.0",
+        "@fuel-ts/crypto": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/utils": "^0.96.1",
         "@noble/hashes": "^1.5.0",
         "bech32": "^2.0.0"
       },
@@ -3038,23 +3038,23 @@
       }
     },
     "node_modules/@fuel-ts/contract": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/contract/-/contract-0.96.0.tgz",
-      "integrity": "sha512-HlMtR+MVUGgQby6NU5/ezO5Li8zfjYrezvaAlVoJtm68r2QDZkeQId4JtD2za7Z1Im6A3eAm4nk9gUIHo6eluw==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/contract/-/contract-0.96.1.tgz",
+      "integrity": "sha512-shwNMHFZ7vr5QJsfVQ6aLd1ms88f3ZagrsNLqNz1Txhz/5KVgYyJaxfp7tUc4WZFpR67+W1zeIqx8ZNHVhck3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/abi-coder": "0.96.0",
-        "@fuel-ts/account": "0.96.0",
-        "@fuel-ts/crypto": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/hasher": "0.96.0",
-        "@fuel-ts/interfaces": "^0.96.0",
-        "@fuel-ts/math": "^0.96.0",
-        "@fuel-ts/merkle": "0.96.0",
-        "@fuel-ts/program": "0.96.0",
-        "@fuel-ts/transactions": "0.96.0",
-        "@fuel-ts/utils": "0.96.0",
-        "@fuel-ts/versions": "0.96.0",
+        "@fuel-ts/abi-coder": "0.96.1",
+        "@fuel-ts/account": "0.96.1",
+        "@fuel-ts/crypto": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/hasher": "0.96.1",
+        "@fuel-ts/interfaces": "^0.96.1",
+        "@fuel-ts/math": "^0.96.1",
+        "@fuel-ts/merkle": "0.96.1",
+        "@fuel-ts/program": "0.96.1",
+        "@fuel-ts/transactions": "0.96.1",
+        "@fuel-ts/utils": "0.96.1",
+        "@fuel-ts/versions": "0.96.1",
         "@fuels/vm-asm": "0.58.0",
         "ramda": "^0.30.1"
       },
@@ -3063,15 +3063,15 @@
       }
     },
     "node_modules/@fuel-ts/crypto": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/crypto/-/crypto-0.96.0.tgz",
-      "integrity": "sha512-Vl76bhtQj3HliXwm3ihgh2zsIK1jsY/eX8XdgCoc8MmQxureNLdbuxv/PKuqRNcUCWkMdhKj11fitwzGVs5VRA==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/crypto/-/crypto-0.96.1.tgz",
+      "integrity": "sha512-OrAZPZtm8HQouzip621/ci47PeTS06QegGdz7MeN6wK4yeCbJmlRQ1WE9S3iclb3p+VLF0RtbecEbHQfsNgsnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/utils": "^0.96.0",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/utils": "^0.96.1",
         "@noble/hashes": "^1.5.0"
       },
       "engines": {
@@ -3091,26 +3091,26 @@
       }
     },
     "node_modules/@fuel-ts/errors": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/errors/-/errors-0.96.0.tgz",
-      "integrity": "sha512-PXR+gaa8UNIYJuzs/doDLwPNyqU1ctp691XVhWS+usRRqiLPgcS2+0rUKF2lr5kdfH7RWEdzU/muymVOJBpOWA==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/errors/-/errors-0.96.1.tgz",
+      "integrity": "sha512-Xtso5v4a3UUvnMaOSDhMRlkb9LxLyCyC/1/RY7fZZ035ttscy6dNMuiD/iSptJ5pHklJ5R4rCPdOL5EKpgOaMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/versions": "0.96.0"
+        "@fuel-ts/versions": "0.96.1"
       },
       "engines": {
         "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
       }
     },
     "node_modules/@fuel-ts/hasher": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/hasher/-/hasher-0.96.0.tgz",
-      "integrity": "sha512-Zo53yBx1WHbm0j6h5F1j/drDv1yfxW3NLovJFIL4PBRObrU/DlWtiBufkAMWZa1q3IIX1zji8oTIf/7zPIDJkw==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/hasher/-/hasher-0.96.1.tgz",
+      "integrity": "sha512-7z4cah+5TOcCBA2Wgvje1L7wVTahiFLb9IUpRXRMVGXwaqsbV/wUNcyuc1mhPh/JKLgcOe+OqsrpcYD2dg2rpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/crypto": "0.96.0",
-        "@fuel-ts/interfaces": "^0.96.0",
-        "@fuel-ts/utils": "0.96.0",
+        "@fuel-ts/crypto": "0.96.1",
+        "@fuel-ts/interfaces": "^0.96.1",
+        "@fuel-ts/utils": "0.96.1",
         "@noble/hashes": "^1.5.0"
       },
       "engines": {
@@ -3130,21 +3130,21 @@
       }
     },
     "node_modules/@fuel-ts/interfaces": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/interfaces/-/interfaces-0.96.0.tgz",
-      "integrity": "sha512-/9hhmnokFvELhsufPMNuSVc+q2FueGDEPQ2AMOrgbnefBvB6y8ON5t7yjapQo/s8BVxUWIdvlnCS2Cn9OUJ/iQ==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/interfaces/-/interfaces-0.96.1.tgz",
+      "integrity": "sha512-mZ3sDHJml5AtLRSmGWo5rbU9//3oKDhAeiFealajcPaVztAAnaKnA5a19dd4ITbjZb2q3e2lQ7zX8iAXgHUwYA==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
       }
     },
     "node_modules/@fuel-ts/math": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/math/-/math-0.96.0.tgz",
-      "integrity": "sha512-DZW4kEAR5BbTuWAonakaigCpW9nHuVuLXTwqMUyYbIRy/mYzAA2ui713F/Yn67GBCVRez3bOXzUc7TH2QUNKRg==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/math/-/math-0.96.1.tgz",
+      "integrity": "sha512-AZUChguQmE1ILYbcc6SOTjFJIUkGzD3Z6yHgvO4tszn2QS/jVTSAZKVx653J5u9m/Xn/WthwR35l1GbwXMwB4g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/errors": "0.96.0",
+        "@fuel-ts/errors": "0.96.1",
         "@types/bn.js": "^5.1.6",
         "bn.js": "^5.2.1"
       },
@@ -3153,32 +3153,32 @@
       }
     },
     "node_modules/@fuel-ts/merkle": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/merkle/-/merkle-0.96.0.tgz",
-      "integrity": "sha512-ZIWq8qLx2BHussNp1AyTx5MZY7ersgPrWrVq5LULgUZaE4z8nY9DNSyLblwTlET3cs+u4umNRkjrm0AEkvyGpA==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/merkle/-/merkle-0.96.1.tgz",
+      "integrity": "sha512-7cLbxYG5berKSK+wPKrkbB9dZ6akOm7C1Ij4iwYXOxQWlmXY62mjSY5Tl1PPyDBSdRqBtqxW0xYUGIzZl2A/3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/hasher": "^0.96.0",
-        "@fuel-ts/math": "0.96.0"
+        "@fuel-ts/hasher": "^0.96.1",
+        "@fuel-ts/math": "0.96.1"
       },
       "engines": {
         "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
       }
     },
     "node_modules/@fuel-ts/program": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/program/-/program-0.96.0.tgz",
-      "integrity": "sha512-OXtKOm0zsDl7U9NrBFr8Q92piH87OAZMDBpvCJesv8IGXqLR6+O0MhNa8RDls5gIf5pgGyd1LyWzfTHOdiRv9A==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/program/-/program-0.96.1.tgz",
+      "integrity": "sha512-tA2YvcIdlDQLKeOOfoTyfI3LRQZiqsHi5rFaGbOsjEQvyNQBdXa92vMMFW0dFNWXqOPLjTmYNWqp0xsMuikbsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/abi-coder": "0.96.0",
-        "@fuel-ts/account": "0.96.0",
-        "@fuel-ts/address": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/transactions": "0.96.0",
-        "@fuel-ts/utils": "0.96.0",
+        "@fuel-ts/abi-coder": "0.96.1",
+        "@fuel-ts/account": "0.96.1",
+        "@fuel-ts/address": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/transactions": "0.96.1",
+        "@fuel-ts/utils": "0.96.1",
         "@fuels/vm-asm": "0.58.0",
         "ramda": "^0.30.1"
       },
@@ -3187,53 +3187,53 @@
       }
     },
     "node_modules/@fuel-ts/script": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/script/-/script-0.96.0.tgz",
-      "integrity": "sha512-3X3G+vMLjWQfIP2TY+riHYJ5jJV6/ii7yRfkHyKJ0ntnY59kLVfsA97BkXVAe1GFdV0Hw8xXRPhDlCPIuABTYQ==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/script/-/script-0.96.1.tgz",
+      "integrity": "sha512-N/N3I3xjDI1+9XcCrYTWapF0iBbdvtBxUUUZxn5S5GuIXuTCK6UfQLrRciuCHK5QiHVwFmQjlki+ozJfI+4UbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/abi-coder": "0.96.0",
-        "@fuel-ts/account": "0.96.0",
-        "@fuel-ts/address": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/program": "0.96.0",
-        "@fuel-ts/transactions": "0.96.0",
-        "@fuel-ts/utils": "0.96.0"
+        "@fuel-ts/abi-coder": "0.96.1",
+        "@fuel-ts/account": "0.96.1",
+        "@fuel-ts/address": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/program": "0.96.1",
+        "@fuel-ts/transactions": "0.96.1",
+        "@fuel-ts/utils": "0.96.1"
       },
       "engines": {
         "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
       }
     },
     "node_modules/@fuel-ts/transactions": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/transactions/-/transactions-0.96.0.tgz",
-      "integrity": "sha512-hLRgfO+DlpJHWBDcuCW9vh8yh8kQh/nuhtK/VlfknfITFR+gCcnJCqtEtP95qOwElqkiRBm9+VQJBK3qATWPVA==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/transactions/-/transactions-0.96.1.tgz",
+      "integrity": "sha512-yPQBzMeFIzNBLUZigaf4q0hETO8AH8Evt6ZvpWrYhjYz2WfEpfNDpuhIHRwsMfJRbxz2vhQ51AzkRqpH0b2GMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/abi-coder": "0.96.0",
-        "@fuel-ts/address": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/hasher": "^0.96.0",
-        "@fuel-ts/interfaces": "^0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/utils": "0.96.0"
+        "@fuel-ts/abi-coder": "0.96.1",
+        "@fuel-ts/address": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/hasher": "^0.96.1",
+        "@fuel-ts/interfaces": "^0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/utils": "0.96.1"
       },
       "engines": {
         "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
       }
     },
     "node_modules/@fuel-ts/utils": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/utils/-/utils-0.96.0.tgz",
-      "integrity": "sha512-ME5xLtXocxszic9kIfT51oYAeJdeaCSlvBhAyFzAAyLlbkcL/pPU1d35Dm0ghyxMTEAOO/11CXMBPESIdM54aw==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/utils/-/utils-0.96.1.tgz",
+      "integrity": "sha512-XXZNEUPf7qtKpVO3ak2CSroBYEKh1Gne1zlmVSNUoVPqQvglcu0I2pu/QmVnZBN4m3yVSyHUoWR2Kbo8/Dh7sA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/versions": "0.96.0",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/versions": "0.96.1",
         "fflate": "^0.8.2"
       },
       "engines": {
@@ -3241,9 +3241,9 @@
       }
     },
     "node_modules/@fuel-ts/versions": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/@fuel-ts/versions/-/versions-0.96.0.tgz",
-      "integrity": "sha512-uffrtpkCguzsVkCLW7tuZG1BwNu69LCjy8sO831VcpZsDRzIy3qO/om9X17W2HTJXxSS+25ok4t7fThIF+w6Gg==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/@fuel-ts/versions/-/versions-0.96.1.tgz",
+      "integrity": "sha512-C//ZT7U68Gksz9PzUJVzdzUARK7mfXf3MsF5ZqZaMegkE2tCy+twjy8PBdeVserY0uX6mEHRJyZJwcspk34ixg==",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "4",
@@ -3257,9 +3257,9 @@
       }
     },
     "node_modules/@fuels/connectors": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@fuels/connectors/-/connectors-0.35.0.tgz",
-      "integrity": "sha512-V4rKWk3M8yCy/DXk/hXMEXMhPw2jVkCx4By9IKMzfCizc8u5kSwzDi6na5//y/HGwTp3TyQ2rj22pggdSR6qZQ==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@fuels/connectors/-/connectors-0.35.1.tgz",
+      "integrity": "sha512-obbFp6M0AsSi9JsIiZVslTWq2SbOlIG0NUWcFcNFDbBED1U/Hod1xb5oHcyNvvjpx3gxBixQbUHwnuE5KtFHZA==",
       "dependencies": {
         "@ethereumjs/util": "9.0.3",
         "@ethersproject/bytes": "5.7.0",
@@ -3304,9 +3304,9 @@
       }
     },
     "node_modules/@fuels/react": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@fuels/react/-/react-0.35.0.tgz",
-      "integrity": "sha512-3QmhCqCNua+/eCawy3jTuIOJNCEhNmCRP2P3FAXDw70x78upbtmdMEdnX9RJ8MyF6w73R0KzBiEuM4iR1UWW5g==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@fuels/react/-/react-0.35.1.tgz",
+      "integrity": "sha512-duFT5oh/vEIf0CJ16afIjIhvO7eCxaR3WapubLxA8YtS/czHNPkcURITH427T95ViJEGKPJVCYnWNkMSW4iA8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "1.1.1",
@@ -11260,27 +11260,27 @@
       }
     },
     "node_modules/fuels": {
-      "version": "0.96.0",
-      "resolved": "https://registry.npmjs.org/fuels/-/fuels-0.96.0.tgz",
-      "integrity": "sha512-T3MhpoOPA5VBc7Vw+UJBZLUB0nN73jUjueifzKYUeRhTTPypkTYZ69r8S4825/qsay8kKtingHPcxcGhccHBww==",
+      "version": "0.96.1",
+      "resolved": "https://registry.npmjs.org/fuels/-/fuels-0.96.1.tgz",
+      "integrity": "sha512-BquRIJ0qHNKwhqBTNa6X4aghqhCj1Qz0jM+P0bziXAEk7gVJJZWRz10jCcAgZVeEb4AMdZLDsnNzKJ51GH8IvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fuel-ts/abi-coder": "0.96.0",
-        "@fuel-ts/abi-typegen": "0.96.0",
-        "@fuel-ts/account": "0.96.0",
-        "@fuel-ts/address": "0.96.0",
-        "@fuel-ts/contract": "0.96.0",
-        "@fuel-ts/crypto": "0.96.0",
-        "@fuel-ts/errors": "0.96.0",
-        "@fuel-ts/hasher": "0.96.0",
-        "@fuel-ts/interfaces": "0.96.0",
-        "@fuel-ts/math": "0.96.0",
-        "@fuel-ts/merkle": "0.96.0",
-        "@fuel-ts/program": "0.96.0",
-        "@fuel-ts/script": "0.96.0",
-        "@fuel-ts/transactions": "0.96.0",
-        "@fuel-ts/utils": "0.96.0",
-        "@fuel-ts/versions": "0.96.0",
+        "@fuel-ts/abi-coder": "0.96.1",
+        "@fuel-ts/abi-typegen": "0.96.1",
+        "@fuel-ts/account": "0.96.1",
+        "@fuel-ts/address": "0.96.1",
+        "@fuel-ts/contract": "0.96.1",
+        "@fuel-ts/crypto": "0.96.1",
+        "@fuel-ts/errors": "0.96.1",
+        "@fuel-ts/hasher": "0.96.1",
+        "@fuel-ts/interfaces": "0.96.1",
+        "@fuel-ts/math": "0.96.1",
+        "@fuel-ts/merkle": "0.96.1",
+        "@fuel-ts/program": "0.96.1",
+        "@fuel-ts/script": "0.96.1",
+        "@fuel-ts/transactions": "0.96.1",
+        "@fuel-ts/utils": "0.96.1",
+        "@fuel-ts/versions": "0.96.1",
         "bundle-require": "^5.0.0",
         "chalk": "4",
         "chokidar": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@fuels/connectors": "0.35.0",
-    "@fuels/react": "0.35.0",
+    "@fuels/connectors": "0.35.1",
+    "@fuels/react": "0.35.1",
     "@tanstack/react-query": "^5.50.1",
     "clsx": "^2.1.1",
-    "fuels": "^0.96.0",
+    "fuels": "^0.96.1",
     "graphql": "^16.9.0",
     "graphql-request": "^7.1.0",
     "mira-dex-ts": "^1.0.27",


### PR DESCRIPTION
Updates `fuels` versions to the latest

```
LICENSE:
The Fuel Support team submits this PR to help you use the fuel SDKs. It is provided "as is" 
and without warranty for any purpose. We are not participants in the project at hand. 
All the rights of this code are reserved to the authors of this repository.
```