### PR TITLE
BugFix: Over-reporting of rewards

### DIFF
--- a/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
+++ b/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
@@ -56,7 +56,7 @@ const BoostsRewards = (): JSX.Element => {
     return () => clearInterval(interval);
   }, [startDate, endDate]);
 
-  const fuelCount = calculateFuelAmount(rewardsAmount, fuelToUsdRate);
+  const fuelCount = parseFloat(rewardsAmount.toFixed(2));
   const usdValue = calculateUsdValue(fuelCount, fuelToUsdRate);
 
   const loading = isLoading || isRewardsAmountLoading;

--- a/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
+++ b/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
@@ -12,7 +12,6 @@ import {
 import {useEffect, useState} from "react";
 import {
   calculateEpochDuration,
-  calculateFuelAmount,
   calculateUsdValue,
   getRewardsPoolsId,
 } from "@/src/utils/common";

--- a/src/models/campaigns.json
+++ b/src/models/campaigns.json
@@ -15,7 +15,7 @@
                 },
                 "rewards": [
                     {
-                        "amount": 15000,
+                        "dailyAmount": 15000,
                         "assetId": "0x1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82"
                     }
                 ]
@@ -31,7 +31,7 @@
                 },
                 "rewards": [
                     {
-                        "amount": 30000,
+                        "dailyAmount": 30000,
                         "assetId": "0x1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82"
                     }
                 ]
@@ -47,7 +47,7 @@
                 },
                 "rewards": [
                     {
-                        "amount": 50000,
+                        "dailyAmount": 50000,
                         "assetId": "0x1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82"
                     }
                 ]

--- a/src/models/campaigns/interfaces.ts
+++ b/src/models/campaigns/interfaces.ts
@@ -15,7 +15,7 @@ export interface EpochConfig {
       lpToken: string;
     };
     rewards: {
-      amount: number;
+      dailyAmount: number;
       assetId: string;
     }[];
   }[];
@@ -23,7 +23,7 @@ export interface EpochConfig {
 
 export interface CampaignReward {
   assetId: string;
-  amount: number;
+  dailyAmount: number;
 }
 
 export interface Epoch {

--- a/src/models/rewards/UserRewards.ts
+++ b/src/models/rewards/UserRewards.ts
@@ -46,7 +46,7 @@ const getQueryOptions = (
             epochEnd: {timestampValue: epochEnd},
             userId: {stringValue: userId},
             lpToken: {stringValue: lpToken},
-            lpTokenAmount: {intValue: lpTokenAmount},
+            rewardsAmount: {intValue: lpTokenAmount},
             campaignRewardToken: {stringValue: campaignRewardToken},
           },
         },

--- a/src/models/rewards/UserRewards.ts
+++ b/src/models/rewards/UserRewards.ts
@@ -144,13 +144,21 @@ export class SentioJSONUserRewardsService implements UserRewardsService {
         throw new Error(`Invalid epoch end time: ${epochEnd}`);
       }
 
+      // Amount represents daily rewards than total epoch rewards
+      // We have to adjust the amount based on the number of days in the epoch
+      const epochDurationDays =
+        (new Date(epochEnd).getTime() - new Date(epochStart).getTime()) /
+        (1000 * 60 * 60 * 24);
+      const campaignRewardAmount =
+        campaign.rewards[0].amount * epochDurationDays;
+
       const options = getQueryOptions(
         this.apiKey,
         epochStart,
         epochEnd,
         userId,
         lpToken,
-        campaign.rewards[0].amount,
+        campaignRewardAmount,
         "fuel",
       );
 

--- a/src/models/rewards/UserRewards.ts
+++ b/src/models/rewards/UserRewards.ts
@@ -12,6 +12,7 @@ import {
 import {NotFoundError} from "@/src/utils/errors";
 import path from "path";
 import {Campaign, EpochConfigService} from "../campaigns/interfaces";
+import {convertDailyRewardsToTotalRewards} from "@/src/utils/common";
 
 const userPoolRewardsQuery = loadFile(
   path.join(process.cwd(), "src", "queries", "UserPoolRewards.sql"),
@@ -144,13 +145,11 @@ export class SentioJSONUserRewardsService implements UserRewardsService {
         throw new Error(`Invalid epoch end time: ${epochEnd}`);
       }
 
-      // Amount represents daily rewards than total epoch rewards
-      // We have to adjust the amount based on the number of days in the epoch
-      const epochDurationDays =
-        (new Date(epochEnd).getTime() - new Date(epochStart).getTime()) /
-        (1000 * 60 * 60 * 24);
-      const campaignRewardAmount =
-        campaign.rewards[0].dailyAmount * epochDurationDays;
+      const campaignRewardAmount = convertDailyRewardsToTotalRewards(
+        campaign.rewards[0].dailyAmount,
+        epochStart,
+        epochEnd,
+      );
 
       const options = getQueryOptions(
         this.apiKey,

--- a/src/models/rewards/UserRewards.ts
+++ b/src/models/rewards/UserRewards.ts
@@ -150,7 +150,7 @@ export class SentioJSONUserRewardsService implements UserRewardsService {
         (new Date(epochEnd).getTime() - new Date(epochStart).getTime()) /
         (1000 * 60 * 60 * 24);
       const campaignRewardAmount =
-        campaign.rewards[0].amount * epochDurationDays;
+        campaign.rewards[0].dailyAmount * epochDurationDays;
 
       const options = getQueryOptions(
         this.apiKey,

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,7 @@
 import {CoinName, coinsConfig} from "@/src/utils/coinsConfig";
 import {B256Address} from "fuels";
 import {buildPoolId, PoolId} from "mira-dex-ts";
+import {DefaultLocale} from "./constants";
 
 export const openNewTab = (url: string) => {
   window.open(url, "_blank");
@@ -130,18 +131,7 @@ export const calculateUsdValue = (
   fuelToUsdRate: number,
 ): string => {
   const usdValue = fuelAmount * fuelToUsdRate;
-  return `~$${usdValue.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
-};
-
-export const calculateFuelAmount = (
-  rewardsAmount: number,
-  fuelToUsdRate: number,
-): number => {
-  const fuelAmount = rewardsAmount / fuelToUsdRate;
-  return parseFloat(fuelAmount.toFixed(2));
+  return `~${usdValue.toLocaleString(DefaultLocale, {style: "currency", currency: "USD"})}`;
 };
 
 export const calculateEpochDuration = (

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -174,3 +174,14 @@ export const calculateEpochDuration = (
     return "Season has ended";
   }
 };
+
+export const convertDailyRewardsToTotalRewards = (
+  dailyRewards: number,
+  epochStart: string,
+  epochEnd: string,
+) => {
+  const epochDurationDays =
+    (new Date(epochEnd).getTime() - new Date(epochStart).getTime()) /
+    (1000 * 60 * 60 * 24);
+  return dailyRewards * epochDurationDays;
+};

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -108,13 +108,13 @@ export const getBoostReward = (
       id: string;
     };
     rewards: {
-      amount: number;
+      dailyAmount: number;
     }[];
   }[],
 ): number => {
   const item = data.find((item) => item.pool.id === poolKey.replace(/0x/g, ""));
 
-  return item?.rewards[0].amount || 0;
+  return item?.rewards[0].dailyAmount || 0;
 };
 
 export const getRewardsPoolsId = (


### PR DESCRIPTION
## Issue
After adjusting for the following:

"The frontend treats campaigns.json as if rewards describe daily rewards, api treats it as if they are total season rewards."

It was found that rewards were being over-reported for all addresses. There were two issues that were causing this:
1. Frontend was treating fuel rewards as USD rewards
2. The rewards query had an issue with the denominator of number of hours elapsed using number of snapshots.

### Frontend Issue
Easy fix with a few lines of JS

### Query issue
The query used hourly_balance snapshot count as the denominator for number of hours elapsed, adjusting for number of hours using that. This approach was chosen as to not cause a drop in rewards when the snapshots were delayed (numerator and denominator are both based on number of snapshots), and to allow for constant increase of rewards rather than jumps. However asset balance snapshots of zero only show up on some assets and some users (We are unsure as to why that is).  For the pool and users in question zero balance snapshots do not show up.

## Changes
### Daily rewards issue
- Multiply the campaigns[n].rewards[m].amount by the number of days in the season to get seasonRewards then use that value instead
### Rewards Display
- Modify frontend BoostRewards to use the rewards value received as a fuel value rather than a USD.
### User rewards query
- Simplify the UserRewards query and change it to use timestamp derived time elapsed rather than a snapshot based one.
> Limitations of this approach
 Rewards will jump up each hour when a snapshot is indexed. This is a better analogy for the actual distribution of rewards, but feels less satisfying to users.