### PR TITLE
Fix: Disable swap action button under appropriate conditions

### DIFF
--- a/src/components/common/Swap/Swap.tsx
+++ b/src/components/common/Swap/Swap.tsx
@@ -506,13 +506,11 @@ const Swap = () => {
 
   const sellAssetPrice = useAssetPrice(swapState.sell.assetId);
   const buyAssetPrice = useAssetPrice(swapState.buy.assetId);
+  const isInsufficientSellAmount = new BN(swapState.sell.amount || 0).gt(sellBalanceValue);
 
   const isActionDisabled =
-    swapDisabled &&
-    !previewLoading &&
-    !balancesPending &&
-    (txCostPending || amountMissing);
-
+  isInsufficientSellAmount || coinMissing || amountMissing || swapPending || !isValidNetwork || !sufficientEthBalance
+  
   //If amount is missing txCostPending is irrelevant
   //If in sufficient fund, previewLoading is irrelevant
   const isActionLoading =

--- a/src/components/common/Swap/Swap.tsx
+++ b/src/components/common/Swap/Swap.tsx
@@ -448,15 +448,6 @@ const Swap = () => {
           sellMetadata.decimals || 0,
         );
 
-  const swapDisabled =
-    !isValidNetwork ||
-    coinMissing ||
-    showInsufficientBalance ||
-    Boolean(previewError) ||
-    !sellValue ||
-    !buyValue ||
-    previewLoading;
-
   useEffect(() => {
     if (!isValidNetwork) {
       setSwapButtonTitle("Incorrect network");
@@ -506,11 +497,18 @@ const Swap = () => {
 
   const sellAssetPrice = useAssetPrice(swapState.sell.assetId);
   const buyAssetPrice = useAssetPrice(swapState.buy.assetId);
-  const isInsufficientSellAmount = new BN(swapState.sell.amount || 0).gt(sellBalanceValue);
+  const isInsufficientSellAmount = new BN(swapState.sell.amount || 0).gt(
+    sellBalanceValue,
+  );
 
   const isActionDisabled =
-  isInsufficientSellAmount || coinMissing || amountMissing || swapPending || !isValidNetwork || !sufficientEthBalance
-  
+    isInsufficientSellAmount ||
+    coinMissing ||
+    amountMissing ||
+    swapPending ||
+    !isValidNetwork ||
+    !sufficientEthBalance;
+
   //If amount is missing txCostPending is irrelevant
   //If in sufficient fund, previewLoading is irrelevant
   const isActionLoading =


### PR DESCRIPTION
### Fixes : #212 
### Improved the logic to disable the swap button based on the following conditions:
- Insufficient sell amount
- Missing coin or amount
- Swap in progress
- Invalid network
- Insufficient ETH balance

![Screenshot (386)](https://github.com/user-attachments/assets/444dd651-05b1-4316-bf48-082eb2bf71b4)
