### PR TITLE
fix: improve token search feedback when no results found

### DIFF
--- a/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
+++ b/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
@@ -8,6 +8,7 @@ import {useAssetList} from "@/src/hooks/useAssetList";
 import UnknownCoinListItem from "../UnknownCoinListItem";
 import {useQuery} from "@tanstack/react-query";
 import {VerifiedAssets} from "../CoinListItem/checkIfCoinVerified";
+import EmptySearchResults from "../EmptySearchResults";
 
 type Props = {
   selectCoin: (assetId: string | null) => void;
@@ -110,7 +111,6 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
       return 0;
     });
   }, [filteredCoinsList, balances]);
-
   return (
     <>
       <div className={styles.tokenSearch}>
@@ -124,12 +124,18 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
         />
       </div>
       <div className={styles.tokenList}>
-        {assetIdRegex.test(value) && sortedCoinsList.length === 0 && (
-          <UnknownCoinListItem
-            assetId={value}
-            balance={balances?.find((b) => b.assetId === value)}
-            onClick={() => selectCoin(value)}
-          />
+        {sortedCoinsList.length === 0 && value !== "" && (
+          <>
+            {assetIdRegex.test(value) ? (
+              <UnknownCoinListItem
+                assetId={value}
+                balance={balances?.find((b) => b.assetId === value)}
+                onClick={() => selectCoin(value)}
+              />
+            ) : (
+              <EmptySearchResults value={value} />
+            )}
+          </>
         )}
         {sortedCoinsList.map(({assetId}) => (
           <div

--- a/src/components/common/Swap/components/EmptySearchResults.tsx
+++ b/src/components/common/Swap/components/EmptySearchResults.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface EmptySearchResultsProps {
+  value: string;
+}
+
+const EmptySearchResults = ({value}: EmptySearchResultsProps) => {
+  return (
+    <div
+      style={{
+        padding: "8px 16px",
+        color: "var(--content-dimmed-light)",
+      }}
+    >
+      {value ? (
+        <span>
+          No results found for{" "}
+          <span style={{color: "var(--content-primary)"}}>"{value}"</span>
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+export default EmptySearchResults;


### PR DESCRIPTION
### Fixes #217 

### Changes made : 
- Instead of modifying the `UnknownCoinListItem.tsx` component directly, I made a new component called `EmptySearchResults` to handle the issue, so that if the search value fails the `assetIdRegex.test(value)` , the message will be displayed.

SS : 
![Screenshot (394)](https://github.com/user-attachments/assets/1ea2dbda-e084-4cb1-b8bf-1130339f868e)
