### PR TITLE
Handle routing failure when output amount exceeds pool reserves

### DIFF
--- a/src/hooks/useSwapPreview.ts
+++ b/src/hooks/useSwapPreview.ts
@@ -167,6 +167,11 @@ const useSwapPreview = ({swapState, mode}: Props) => {
         }
       }
 
+      // Handle the case where input_amount is MAX_U256
+      if (previewData.input_amount.eq(MAX_U256)) {
+        throw new Error("Routing failed");
+      }
+
       return previewData;
     },
     retry: (failureCount, error) => {


### PR DESCRIPTION
Fixes https://github.com/mira-amm/mira-amm-web/issues/230