### PR TITLE
Bugfix/wallet connection

### DIFF
--- a/src/components/common/ConnectButton/ConnectButton.tsx
+++ b/src/components/common/ConnectButton/ConnectButton.tsx
@@ -28,12 +28,14 @@ type Props = {
 };
 
 const ConnectButton = ({className}: Props) => {
-  const {isConnected} = useIsConnected();
+  const {isConnected, isFetching, isPending} = useIsConnected();
   const {connect, isConnecting} = useConnectUI();
   const {disconnect, isPending: disconnectLoading} = useDisconnect();
   const {account} = useAccount();
 
   const {lock, unlock} = useScrollLock({autoLock: false});
+
+  console.log(isFetching, isPending);
 
   // TODO: Hack to avoid empty button when account is changed to the not connected one in wallet
   // It is not reproducible on Fuelet, but on Fuel wallet
@@ -45,7 +47,7 @@ const ConnectButton = ({className}: Props) => {
   //   }
   // }, [account, isConnected]);
 
-  const loading = isConnecting || disconnectLoading;
+  const loading = isConnecting || disconnectLoading || isFetching;
 
   const [isMenuOpened, setMenuOpened] = useState(false);
   const [isHistoryOpened, setHistoryOpened] = useState(false);

--- a/src/components/common/ConnectButton/ConnectButton.tsx
+++ b/src/components/common/ConnectButton/ConnectButton.tsx
@@ -28,14 +28,12 @@ type Props = {
 };
 
 const ConnectButton = ({className}: Props) => {
-  const {isConnected, isFetching, isPending} = useIsConnected();
+  const {isConnected, isFetching} = useIsConnected();
   const {connect, isConnecting} = useConnectUI();
   const {disconnect, isPending: disconnectLoading} = useDisconnect();
   const {account} = useAccount();
 
   const {lock, unlock} = useScrollLock({autoLock: false});
-
-  console.log(isFetching, isPending);
 
   // TODO: Hack to avoid empty button when account is changed to the not connected one in wallet
   // It is not reproducible on Fuelet, but on Fuel wallet


### PR DESCRIPTION
closes [197](https://github.com/mira-amm/mira-amm-web/issues/197)

### Fixed

- [x] Loading state on connect wallet button while connection is establishing

- [ ] Infinite loading state when some error happens

This seems like not a bug.
This mostly happens when the user requested for wallet connection, but haven't approved the request on wallet prompt and the wallet prompt is kept opened. So during this state, the `connection` state will be `loading/ connecting`  like waiting for approval. 

Also when a user is trying to connect the wallet and during the time, if there is any issues like network connection lost, user will still be able to connect, but the `fuel wallet adapter` will not update the `connection` status  to `connected` state. But the wallet should have connected and on refresh of the page, the UI state will be updated to `connected`. It is because that the wallet adapter is not updating the `connected` state to properly. 

### Deferred
- [ ] The wallet pop up show as connected, but the UI show as "connect" (Difficult to reproduce)

This issue mostly happens when you have more than one wallet installed. And is an issue from the `fuel wallet adapter library`

Steps to reproduce:

1. Install both `fuel` and `fuelet` wallets. 
2. Connect one of the wallet with the dapp.
3. Duplicate the current tab
4. Disconnect the wallet in one of the tab
5. Connect with the other wallet (if first wallet was fuel, connect with fuelet or vice versa)
6. Check the next tab, most probably the wallet connect button shows as `disconnected` state while the wallet select modal shows the connected state. 

This is the most easiest  way to reproduce the issue, but also the issue happens in different scenario where we have multiple tabs opened, and most of the time clicking again on the wallet will set  the wallet  to connected state in UI. 

Reason for the issue:

The fuel wallet adapter is not updating the `connected`  state of user or the `account` of the user during this time. As we are completely depending of the fuel wallet adapter, we can raise an issue on their community/ channel

