### PR TITLE
bugfix: token not displayed on search by address

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
+++ b/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
@@ -124,9 +124,6 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
     });
   }, [filteredCoinsList, balances]);
 
-  console.log("sortedCoinsList", sortedCoinsList);
-  console.log("filteredCoinsList", filteredCoinsList);
-
   return (
     <>
       <div className={styles.tokenSearch}>

--- a/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
+++ b/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
@@ -49,8 +49,8 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
     return (
       coin.name?.toLowerCase().includes(lowerCaseValue) ||
       coin.symbol?.toLowerCase().includes(lowerCaseValue) ||
-      coin.assetId?.toLowerCase() === value ||
-      coin.l1Address?.toLowerCase() === value
+      coin.assetId?.toLowerCase() === lowerCaseValue ||
+      coin.l1Address?.toLowerCase() === lowerCaseValue
     );
   };
 
@@ -123,6 +123,9 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
       return 0;
     });
   }, [filteredCoinsList, balances]);
+
+  console.log("sortedCoinsList", sortedCoinsList);
+  console.log("filteredCoinsList", filteredCoinsList);
 
   return (
     <>

--- a/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
+++ b/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
@@ -9,6 +9,7 @@ import UnknownCoinListItem from "../UnknownCoinListItem";
 import {useQuery} from "@tanstack/react-query";
 import {VerifiedAssets} from "../CoinListItem/checkIfCoinVerified";
 import EmptySearchResults from "../EmptySearchResults";
+import {CoinDataWithPrice} from "@/src/utils/coinsConfig";
 
 type Props = {
   selectCoin: (assetId: string | null) => void;
@@ -24,7 +25,6 @@ const assetIdRegex = /^0x[0-9a-fA-F]{64}$/;
 const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
   const {assets} = useAssetList();
   const [value, setValue] = useState("");
-
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -37,19 +37,31 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
     setValue(e.target.value);
   };
 
+  const filterByVerification = (
+    coin: CoinDataWithPrice,
+    verifiedAssetsOnly?: boolean,
+  ) => {
+    return !verifiedAssetsOnly || coin.isVerified;
+  };
+
+  const filterBySearchValue = (coin: CoinDataWithPrice, value: string) => {
+    const lowerCaseValue = value.toLowerCase();
+    return (
+      coin.name?.toLowerCase().includes(lowerCaseValue) ||
+      coin.symbol?.toLowerCase().includes(lowerCaseValue) ||
+      coin.assetId?.toLowerCase() === value ||
+      coin.l1Address?.toLowerCase() === value
+    );
+  };
+
   const filteredCoinsList = useMemo(() => {
     return (assets || []).filter((coin) => {
-      if (verifiedAssetsOnly && !coin.isVerified) {
-        return false;
-      }
-
       return (
-        coin.name?.toLowerCase().includes(value.toLowerCase()) ||
-        coin.symbol?.toLowerCase().includes(value.toLowerCase()) ||
-        coin.assetId?.toLowerCase() === value.toLowerCase()
+        filterByVerification(coin, verifiedAssetsOnly) &&
+        filterBySearchValue(coin, value)
       );
     });
-  }, [verifiedAssetsOnly, value, assets]);
+  }, [assets, verifiedAssetsOnly, value]);
 
   // TODO: Pre-sort the list by priorityOrder and alphabet to avoid sorting each time
   const sortedCoinsList = useMemo(() => {
@@ -111,6 +123,7 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
       return 0;
     });
   }, [filteredCoinsList, balances]);
+
   return (
     <>
       <div className={styles.tokenSearch}>


### PR DESCRIPTION
### Overview

The pull request contains a bug fix that allows users to search for token by using the correct token address. Users are able to use L1 addresses supported by the platform to search for them among the list. It also includes some cleanup in the filtering function by breaking it down into smaller functions to make it easy to read and follow.

## Screen shots:
https://www.loom.com/share/744733427f874fb580c9ee8b0dd0d7b5?sid=3e800b96-bab7-4fe8-b017-f8d30b584a02