### PR TITLE
feat: new fuel asset price api integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
+++ b/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
@@ -124,9 +124,6 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
     });
   }, [filteredCoinsList, balances]);
 
-  console.log("sortedCoinsList", sortedCoinsList);
-  console.log("filteredCoinsList", filteredCoinsList);
-
   return (
     <>
       <div className={styles.tokenSearch}>

--- a/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
+++ b/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
@@ -49,8 +49,8 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
     return (
       coin.name?.toLowerCase().includes(lowerCaseValue) ||
       coin.symbol?.toLowerCase().includes(lowerCaseValue) ||
-      coin.assetId?.toLowerCase() === value ||
-      coin.l1Address?.toLowerCase() === value
+      coin.assetId?.toLowerCase() === lowerCaseValue ||
+      coin.l1Address?.toLowerCase() === lowerCaseValue
     );
   };
 
@@ -123,6 +123,9 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
       return 0;
     });
   }, [filteredCoinsList, balances]);
+
+  console.log("sortedCoinsList", sortedCoinsList);
+  console.log("filteredCoinsList", filteredCoinsList);
 
   return (
     <>

--- a/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
+++ b/src/components/common/Swap/components/CoinsListModal/CoinsListModal.tsx
@@ -9,6 +9,7 @@ import UnknownCoinListItem from "../UnknownCoinListItem";
 import {useQuery} from "@tanstack/react-query";
 import {VerifiedAssets} from "../CoinListItem/checkIfCoinVerified";
 import EmptySearchResults from "../EmptySearchResults";
+import {CoinDataWithPrice} from "@/src/utils/coinsConfig";
 
 type Props = {
   selectCoin: (assetId: string | null) => void;
@@ -24,7 +25,6 @@ const assetIdRegex = /^0x[0-9a-fA-F]{64}$/;
 const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
   const {assets} = useAssetList();
   const [value, setValue] = useState("");
-
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -37,19 +37,31 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
     setValue(e.target.value);
   };
 
+  const filterByVerification = (
+    coin: CoinDataWithPrice,
+    verifiedAssetsOnly?: boolean,
+  ) => {
+    return !verifiedAssetsOnly || coin.isVerified;
+  };
+
+  const filterBySearchValue = (coin: CoinDataWithPrice, value: string) => {
+    const lowerCaseValue = value.toLowerCase();
+    return (
+      coin.name?.toLowerCase().includes(lowerCaseValue) ||
+      coin.symbol?.toLowerCase().includes(lowerCaseValue) ||
+      coin.assetId?.toLowerCase() === value ||
+      coin.l1Address?.toLowerCase() === value
+    );
+  };
+
   const filteredCoinsList = useMemo(() => {
     return (assets || []).filter((coin) => {
-      if (verifiedAssetsOnly && !coin.isVerified) {
-        return false;
-      }
-
       return (
-        coin.name?.toLowerCase().includes(value.toLowerCase()) ||
-        coin.symbol?.toLowerCase().includes(value.toLowerCase()) ||
-        coin.assetId?.toLowerCase() === value.toLowerCase()
+        filterByVerification(coin, verifiedAssetsOnly) &&
+        filterBySearchValue(coin, value)
       );
     });
-  }, [verifiedAssetsOnly, value, assets]);
+  }, [assets, verifiedAssetsOnly, value]);
 
   // TODO: Pre-sort the list by priorityOrder and alphabet to avoid sorting each time
   const sortedCoinsList = useMemo(() => {
@@ -111,6 +123,7 @@ const CoinsListModal = ({selectCoin, balances, verifiedAssetsOnly}: Props) => {
       return 0;
     });
   }, [filteredCoinsList, balances]);
+
   return (
     <>
       <div className={styles.tokenSearch}>

--- a/src/hooks/useAssetPrice.ts
+++ b/src/hooks/useAssetPrice.ts
@@ -1,16 +1,11 @@
 import {useQuery} from "@tanstack/react-query";
 import {useAssetMinterContract} from "./useAssetMinterContract";
-import useProvider from "./useProvider/useProvider";
-import src7Abi from "@/src/abis/src7-abi.json";
-import {Contract, Provider} from "fuels";
-import {NetworkUrl} from "../utils/constants";
+import {FuelAssetPriceUrl} from "../utils/constants";
 
 const ETH_ASSET_ID =
   "0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07";
 const NATIVE_BRIDGE_MINTER_CONTRACT =
   "0x4ea6ccef1215d9479f1024dff70fc055ca538215d2c8c348beddffd54583d0e8";
-
-const providerPromise = Provider.create(NetworkUrl);
 
 export const useAssetPrice = (
   assetId: string | null,
@@ -20,37 +15,10 @@ export const useAssetPrice = (
   const {data, isLoading} = useQuery({
     queryKey: ["assetPrice", assetId],
     queryFn: async () => {
-      const provider = await providerPromise;
-      const src7Contract = new Contract(
-        NATIVE_BRIDGE_MINTER_CONTRACT,
-        src7Abi,
-        provider!,
-      );
-
-      let l1Address: string;
-      if (assetId === ETH_ASSET_ID) {
-        l1Address = "0x0000000000000000000000000000000000000000";
-      } else {
-        const result = await src7Contract.functions
-          .metadata({bits: assetId}, "bridged:address")
-          .addContracts([
-            // The current bridge implementation
-            new Contract(
-              "0x0ceafc5ef55c66912e855917782a3804dc489fb9e27edfd3621ea47d2a281156",
-              src7Abi,
-              provider!,
-            ),
-          ])
-          .get();
-        l1Address = "0x" + result.value.B256.substring(26);
-      }
-
-      const req = await fetch(
-        `https://coins.llama.fi/prices/current/ethereum:${l1Address}`,
-      );
+      const req = await fetch(`${FuelAssetPriceUrl}/${assetId}`);
       const res = await req.json();
 
-      return res.coins[`ethereum:${l1Address}`]?.price || null;
+      return res.rate || null;
     },
     enabled:
       !!assetId &&

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -35,6 +35,9 @@ export const ApiBaseUrl = "https://prod.api.mira.ly" as const;
 
 export const FuelAppUrl = "https://app.fuel.network" as const;
 
+export const FuelAssetPriceUrl =
+  " https://explorer-indexer-mainnet.fuel.network/assets" as const;
+
 export const EthDecimals = 9 as const;
 export const MinEthValue = 0.0001 as const;
 export const MinEthValueBN = MinEthValue * 10 ** EthDecimals;


### PR DESCRIPTION
### Overview

This pr includes the introduction of a new api to get Fuel asset prices. The new api provides a straight forward approach in getting prices for Fuel assets. It has a rate field that contains the USD equivalent of the asset. Very useful during the swap flow, as we won't need to look for the corresponding L1 address as previously implemented with the old api.