### PR TITLE
FIX: Dollar Value Overflow in Swap and AddLiquidity page

### DIFF
--- a/src/components/common/Swap/components/CurrencyBox/CurrencyBox.tsx
+++ b/src/components/common/Swap/components/CurrencyBox/CurrencyBox.tsx
@@ -13,7 +13,7 @@ import {InsufficientReservesError} from "mira-dex-ts/dist/sdk/errors";
 import {NoRouteFoundError} from "@/src/hooks/useSwapPreview";
 import {B256Address, BN} from "fuels";
 import useAssetMetadata from "@/src/hooks/useAssetMetadata";
-
+import abbreviateNumber from "@/src/utils/abbreviateNumber";
 type Props = {
   value: string;
   assetId: B256Address | null;
@@ -75,10 +75,7 @@ const CurrencyBox = ({
   const numericValue = parseFloat(value);
   const usdValue =
     !isNaN(numericValue) && Boolean(usdRate)
-      ? (numericValue * usdRate!).toLocaleString(DefaultLocale, {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        })
+      ? abbreviateNumber(numericValue * usdRate!)
       : null;
 
   return (

--- a/src/components/pages/add-liquidity-page/components/CoinInput/CoinInput.tsx
+++ b/src/components/pages/add-liquidity-page/components/CoinInput/CoinInput.tsx
@@ -8,6 +8,7 @@ import TextButton from "@/src/components/common/TextButton/TextButton";
 import {DefaultLocale, MinEthValueBN} from "@/src/utils/constants";
 import {BN} from "fuels";
 import useAssetMetadata from "@/src/hooks/useAssetMetadata";
+import abbreviateNumber from "@/src/utils/abbreviateNumber";
 
 type Props = {
   assetId: string | null;
@@ -57,10 +58,7 @@ const CoinInput = ({
   const numericValue = parseFloat(value);
   const usdValue =
     !isNaN(numericValue) && Boolean(usdRate)
-      ? (numericValue * usdRate!).toLocaleString(DefaultLocale, {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        })
+      ? abbreviateNumber(numericValue * usdRate!)
       : null;
 
   return (

--- a/src/utils/abbreviateNumber.ts
+++ b/src/utils/abbreviateNumber.ts
@@ -1,0 +1,27 @@
+// Convert UsdRate to abbreviated string
+
+const abbreviateNumber = (num: number): string => {
+  const units = [
+    {value: 1e12, suffix: "T"},
+    {value: 1e9, suffix: "B"},
+    {value: 1e6, suffix: "M"},
+  ];
+
+  for (const {value, suffix} of units) {
+    if (num >= value) {
+      return (num / value).toFixed(2) + suffix;
+    }
+  }
+
+  // If the number is in thousands, format with toLocaleString
+  if (num >= 1000) {
+    return num.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  }
+
+  return num.toFixed(2);
+};
+
+export default abbreviateNumber;

--- a/src/utils/abbreviateNumber.ts
+++ b/src/utils/abbreviateNumber.ts
@@ -7,21 +7,24 @@ const abbreviateNumber = (num: number): string => {
     {value: 1e6, suffix: "M"},
   ];
 
+  const formatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
   for (const {value, suffix} of units) {
     if (num >= value) {
-      return (num / value).toFixed(2) + suffix;
+      return formatter.format(num / value) + suffix;
     }
   }
 
-  // If the number is in thousands, format with toLocaleString
+  // If the number is in thousands, format with Intl.NumberFormat
   if (num >= 1000) {
-    return num.toLocaleString(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    });
+    return formatter.format(num);
   }
 
-  return num.toFixed(2);
+  // For numbers below 1,000, use locale formatting
+  return formatter.format(num);
 };
 
 export default abbreviateNumber;

--- a/src/utils/abbreviateNumber.ts
+++ b/src/utils/abbreviateNumber.ts
@@ -7,7 +7,7 @@ const abbreviateNumber = (num: number): string => {
     {value: 1e6, suffix: "M"},
   ];
 
-  const formatter = new Intl.NumberFormat('en-US', {
+  const formatter = new Intl.NumberFormat("en-US", {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
@@ -17,7 +17,6 @@ const abbreviateNumber = (num: number): string => {
       return formatter.format(num / value) + suffix;
     }
   }
-
 
   // For numbers below 1,000, use locale formatting
   return formatter.format(num);

--- a/src/utils/abbreviateNumber.ts
+++ b/src/utils/abbreviateNumber.ts
@@ -18,10 +18,6 @@ const abbreviateNumber = (num: number): string => {
     }
   }
 
-  // If the number is in thousands, format with Intl.NumberFormat
-  if (num >= 1000) {
-    return formatter.format(num);
-  }
 
   // For numbers below 1,000, use locale formatting
   return formatter.format(num);


### PR DESCRIPTION
Closes #261 

Fixed the overflow USD value in Swap page and Add Liquidity page, 
With the new changes, if a user inputs a value like 100 ETH, the system now displays it as "$269,675.00," and for larger amounts such as 10,000 ETH, the value is neatly abbreviated to "$26.78m." These modifications ensure that the displayed dollar values remain within the designated UI boundaries, effectively resolving the overflow issues.

Swap Page:
![image](https://github.com/user-attachments/assets/b2e12cc2-a47d-40de-8daf-04036f8ba906)

Add Liquidity Page: 
![image](https://github.com/user-attachments/assets/5bcf6d7c-ee7a-4583-8a9a-d02e46df8461)

