### PR TITLE
fix: slippage value formatting

### DIFF
--- a/src/components/common/Swap/components/SettingsModalContent/SettingsModalContent.tsx
+++ b/src/components/common/Swap/components/SettingsModalContent/SettingsModalContent.tsx
@@ -49,7 +49,10 @@ const SettingsModalContent = ({
       setSlippage(DefaultSlippageValue);
       return;
     }
-    setSlippage(Math.floor(numericValue * 100));
+    const formattedValue = numericValue * 100;
+    const fixedToTwo = formattedValue.toFixed(2);
+    const flooredValue = Math.floor(Number(fixedToTwo));
+    setSlippage(flooredValue);
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Closes [265](https://github.com/mira-amm/mira-amm-web/issues/265)

### Root Cause

The issue was with formatting the slippage value and Javascript is trying to represent the value with as much precision as possible. So internally when user enters values like `0.58` or `0.57`, and on multiplied by `100`, it can give `57.9999999` or `56.99999999` respectively. And the floored value taken will be the `value - 0.01`.

### Fix

For now since we are multiplying with 100 to make it a `BN` type, before taking the floor of the value, converting it to `toFixed(2)` and taking the floor (to avoid 0.00). If user enters something like `0.5899999` it will round to `0.59`. 

### Deferred

While fixing the issue found another issue. Once the slippage is updated, the `SettingsModalContent` sometimes unmounts and get remounted again. 