### PR TITLE
fix: removing the non functional back button in swap page

### DIFF
--- a/src/components/pages/swap-page/SwapPageLayout.tsx
+++ b/src/components/pages/swap-page/SwapPageLayout.tsx
@@ -3,8 +3,6 @@
 import Header from "@/src/components/common/Header/Header";
 import Footer from "@/src/components/common/Footer/Footer";
 import Swap from "@/src/components/common/Swap/Swap";
-import BackLink from "@/src/components/common/BackLink/BackLink";
-
 import styles from "./SwapPageLayout.module.css";
 
 const SwapPageLayout = () => {
@@ -12,7 +10,6 @@ const SwapPageLayout = () => {
     <div className={styles.swapPage}>
       <Header />
       <main className={styles.swapLayout}>
-        <BackLink chevron />
         <Swap />
       </main>
       <Footer />


### PR DESCRIPTION
closes #289 

The back button on the swap page did not perform any action. Since the swap page is the first page users see upon entering the website, a back button is unnecessary, and most DEX platforms don't include one. Removing it streamlines the user interface.

Before Change:
![image](https://github.com/user-attachments/assets/fe846f5f-2779-4414-a1e9-191d01f35958)

After Change:
![image](https://github.com/user-attachments/assets/54c1124d-681e-43ad-9a3a-162c70d47b61)
