### PR TITLE
Feat: Extend FS1 with a third part

### DIFF
--- a/src/components/common/AprBadge/AprBadge.tsx
+++ b/src/components/common/AprBadge/AprBadge.tsx
@@ -5,6 +5,7 @@ import {clsx} from "clsx";
 import useBoostedApr from "@/src/hooks/useBoostedApr";
 import {isMobile} from "react-device-detect";
 import Loader from "../Loader/Loader";
+import {EPOCH_NUMBER} from "@/src/utils/constants";
 
 interface AprBadgeProps {
   aprValue: string | null;
@@ -23,7 +24,11 @@ const AprBadge: React.FC<AprBadgeProps> = ({
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
-  const {boostedApr, boostReward} = useBoostedApr(poolKey, tvlValue);
+  const {boostedApr, boostReward} = useBoostedApr(
+    poolKey,
+    tvlValue,
+    EPOCH_NUMBER,
+  );
 
   useEffect(() => {
     if (small && isHovered && isMobile) {

--- a/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
+++ b/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
@@ -111,7 +111,8 @@ const BoostsRewards = (): JSX.Element => {
             </Link>
           </p>
           <p className={styles.disclaimer}>
-            Rewards for the first 45 days have already been distributed.
+            Fuel Season 1 is over, and rewards have been sent to
+            participants&apos; wallets.
           </p>
         </div>
         <div className={styles.epochSection}>

--- a/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
+++ b/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
@@ -8,6 +8,7 @@ import {
   boostsEpochTooltip,
   BoostsLearnMoreUrl,
   BoostsRewardsTooltip,
+  EPOCH_NUMBER,
 } from "@/src/utils/constants";
 import {useEffect, useState, useMemo} from "react";
 import {
@@ -21,8 +22,6 @@ import {useRewards} from "@/src/hooks/useRewards";
 import {useAccount} from "@fuels/react";
 import boostRewards from "@/src/models/campaigns.json";
 
-const epochNumber = 2;
-
 const BoostsRewards = (): JSX.Element => {
   const {account} = useAccount();
 
@@ -32,7 +31,7 @@ const BoostsRewards = (): JSX.Element => {
 
   // look up the epoch start and end date from epochNumbers
   const epoch = useMemo(
-    () => boostRewards.find((epoch) => epoch.number === epochNumber),
+    () => boostRewards.find((epoch) => epoch.number === EPOCH_NUMBER),
     [],
   );
 
@@ -44,7 +43,7 @@ const BoostsRewards = (): JSX.Element => {
 
   const {rewardsAmount, isLoading: isRewardsAmountLoading} = useRewards({
     userId: account,
-    epochNumbers: epochNumber,
+    epochNumbers: EPOCH_NUMBER,
     poolIds: rewardsPoolsId,
   });
 
@@ -112,7 +111,7 @@ const BoostsRewards = (): JSX.Element => {
             </Link>
           </p>
           <p className={styles.disclaimer}>
-            Note: Rewards for the first 30 days have already been distributed.
+            Rewards for the first 45 days have already been distributed.
           </p>
         </div>
         <div className={styles.epochSection}>

--- a/src/hooks/useBoostedApr.ts
+++ b/src/hooks/useBoostedApr.ts
@@ -5,10 +5,17 @@ import {getBoostReward} from "../utils/common";
 const useBoostedApr = (
   poolKey: string,
   tvlValue: number,
+  epochNumber: number,
 ): {boostedApr: number; boostReward: number} => {
-  const rewardsData = boostRewards[0].campaigns;
-
+  const boostEpoch = boostRewards.find((epoch) => epoch.number === epochNumber);
+  const rewardsData = boostEpoch?.campaigns;
   const {price: fuelToUsdRate} = useFuelPrice();
+
+  if (!rewardsData) {
+    console.error("No epoch found matching the given epoch number");
+    return {boostedApr: 0, boostReward: 0};
+  }
+
   const boostReward = getBoostReward(poolKey, rewardsData);
   const usdPerYear = fuelToUsdRate * boostReward * 365;
   const boostedApr = (usdPerYear / tvlValue) * 100;

--- a/src/hooks/usePoolNameAndMatch.ts
+++ b/src/hooks/usePoolNameAndMatch.ts
@@ -1,7 +1,13 @@
 import boostRewards from "@/src/models/campaigns.json";
+import {EPOCH_NUMBER} from "../utils/constants";
 
 const usePoolNameAndMatch = (poolKey: string): {isMatching: boolean} => {
-  const rewardsData = boostRewards[0].campaigns;
+  const epoch = boostRewards.find((epoch) => epoch.number === EPOCH_NUMBER);
+  const rewardsData = epoch?.campaigns;
+
+  if (!rewardsData) {
+    return {isMatching: false};
+  }
 
   const isMatching = rewardsData.some(
     (pool) => pool.pool.id === poolKey.replace(/0x/g, ""),

--- a/src/models/campaigns.json
+++ b/src/models/campaigns.json
@@ -90,5 +90,38 @@
         ]
       }
     ]
+  },
+  {
+    "startDate": "2025-03-01T19:00:00.000Z",
+    "endDate": "2025-03-08T19:00:00.000Z",
+    "number": 3,
+    "campaigns": [
+      {
+        "pool": {
+          "symbols": ["USDC", "USDT"],
+          "id": "286c479da40dc953bddc3bb4c453b608bba2e0ac483b077bd475174115395e6b-a0265fb5c32f6e8db3197af3c7eb05c48ae373605b8165b6f4a51c5b0ba4812e-true",
+          "lpToken": "0x5a5d495efc4a4a3bf2f0fda8ceb5453cf4630a407430df1c548d213dc58f31d1"
+        },
+        "rewards": [
+          {
+            "dailyAmount": 15000,
+            "assetId": "0x1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82"
+          }
+        ]
+      },
+      {
+        "pool": {
+          "symbols": ["USDC", "ETH"],
+          "id": "286c479da40dc953bddc3bb4c453b608bba2e0ac483b077bd475174115395e6b-f8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07-false",
+          "lpToken": "0xeb4287b73f6f3374760be1389a5cf8868e607b2e4de90da6bfa9135c76974f61"
+        },
+        "rewards": [
+          {
+            "dailyAmount": 80000,
+            "assetId": "0x1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -65,7 +65,7 @@ export const DisclaimerMessage = `Disclaimer
 5. I understand the risks associated with using decentralized protocols, including the Mira Dex protocol, as outlined in the Terms of Use and Privacy Policy.`;
 
 export const BoostsLearnMoreUrl =
-  "https://mirror.xyz/miraly.eth/kPWlmOIY_HhHQmZMkDb2dU4Sv_GxqgnIt4cQ7TwGZk4" as const;
+  "https://mirror.xyz/miraly.eth/X-80QWbrq4f17L67Yy8QyQBdE5y2okxTzcfJIL-SHCQ" as const;
 
 export const BoostsRewardsTooltip =
   "These are the total Fuel tokens earned that will be distributed at the end of the season. The exact dollar amount will change based on Fuel’s current price. The exact token amount might change.";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,7 +71,7 @@ export const BoostsRewardsTooltip =
   "These are the total Fuel tokens earned that will be distributed at the end of the season. The exact dollar amount will change based on Fuel’s current price. The exact token amount might change.";
 
 export const boostsEpochTooltip =
-  "The current season has been extended by 7 days. All remaining rewards will be distributed at the end of the season.";
+  "The current season is 7 days long. All remaining rewards will be distributed at the end of the season.";
 
 export const RewardsApiUrl = "/api/rewards" as const;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,9 +71,11 @@ export const BoostsRewardsTooltip =
   "These are the total Fuel tokens earned that will be distributed at the end of the season. The exact dollar amount will change based on Fuel’s current price. The exact token amount might change.";
 
 export const boostsEpochTooltip =
-  "Current season lasts for 45 days total. All rewards will be distributed at the end of the season. ";
+  "The current season has been extended by 7 days. All remaining rewards will be distributed at the end of the season.";
 
 export const RewardsApiUrl = "/api/rewards" as const;
 
 export const boosterBannerTitle =
   " Introducing Boost Rewards, earn $FUEL by providing liquidity.";
+
+export const EPOCH_NUMBER = 3 as const;


### PR DESCRIPTION
Boosts Fuel Season 1 has been extended by 7 days. The rewards values are slightly different so the new epoch only has 80K rewards for ETH/USDC and 15K rewards for USDC/USDT.

## Changes
- [x] Add a new epoch 3 with the two specified pool
- [x] Minor language changes to adjust for the new end date of FS1
- [x] Change hooks that read from boosts to use the current epochNumber rather than the first one

## Limitations
- Epoch number has been moved to a const, but is still not necessary as epoch number can be derived from the current date.