### PR TITLE
fix: update url on how to add liquidity doc

### DIFF
--- a/src/components/pages/liquidity-page/LiquidityPageLayout.tsx
+++ b/src/components/pages/liquidity-page/LiquidityPageLayout.tsx
@@ -10,7 +10,10 @@ import StarsIcon from "@/src/components/icons/Stars/StarsIcon";
 import CupIcon from "@/src/components/icons/Cup/CupIcon";
 
 import styles from "./LiquidityPageLayout.module.css";
-import {BoostsLearnMoreUrl} from "@/src/utils/constants";
+import {
+  BoostsLearnMoreUrl,
+  LIQUIDITY_PROVIDING_DOC_URL,
+} from "@/src/utils/constants";
 import Boosts from "./components/Boosts/Boosts";
 
 const LiquidityPageLayout = (): JSX.Element => {
@@ -26,7 +29,7 @@ const LiquidityPageLayout = (): JSX.Element => {
           <PromoBlock
             icon={<StarsIcon />}
             title="Learn about providing liquidity"
-            link="https://mirror.xyz/miraly.eth"
+            link={LIQUIDITY_PROVIDING_DOC_URL}
             linkText="Click here to see the guide"
           />
           <PromoBlock

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -67,6 +67,9 @@ export const DisclaimerMessage = `Disclaimer
 export const BoostsLearnMoreUrl =
   "https://mirror.xyz/miraly.eth/X-80QWbrq4f17L67Yy8QyQBdE5y2okxTzcfJIL-SHCQ" as const;
 
+export const LIQUIDITY_PROVIDING_DOC_URL =
+  "https://docs.mira.ly/user-guides/how-to-add-liquidity" as const;
+
 export const BoostsRewardsTooltip =
   "These are the total Fuel tokens earned that will be distributed at the end of the season. The exact dollar amount will change based on Fuel’s current price. The exact token amount might change.";
 


### PR DESCRIPTION
Closes [309](https://github.com/mira-amm/mira-amm-web/issues/309)

### Changes

- [x] Updated the URL for the “Provide Liquidity” guide to [this link](https://docs.mira.ly/user-guides/how-to-add-liquidity)