### PR TITLE
hotfix:  wrong pool info showing in APR badge

### DIFF
--- a/src/hooks/useBoostedApr.ts
+++ b/src/hooks/useBoostedApr.ts
@@ -23,22 +23,24 @@ const useBoostedApr = (
     return {boostedApr: 0, boostReward: 0, rewardsToken: undefined};
   }
 
-  const boostReward = getBoostReward(poolKey, rewardsData);
+  const {dailyAmount, assetId} = getBoostReward(poolKey, rewardsData);
 
-  const rewardsInfo = rewardsData?.[0]?.rewards[0];
-
-  if (rewardsInfo?.assetId !== FUEL_ASSET_ID) {
+  if (assetId !== FUEL_ASSET_ID) {
     return {
       boostedApr: 0,
-      boostReward: rewardsInfo?.dailyAmount,
+      boostReward: dailyAmount,
       rewardsToken: "Points",
     };
   }
 
-  const usdPerYear = fuelToUsdRate * boostReward * 365;
+  const usdPerYear = fuelToUsdRate * dailyAmount * 365;
   const boostedApr = (usdPerYear / tvlValue) * 100;
   const boostedAprRounded = Math.round(boostedApr * 100) / 100;
-  return {boostedApr: boostedAprRounded, boostReward, rewardsToken: "$FUEL"};
+  return {
+    boostedApr: boostedAprRounded,
+    boostReward: dailyAmount,
+    rewardsToken: "$FUEL",
+  };
 };
 
 export default useBoostedApr;

--- a/src/models/campaigns.json
+++ b/src/models/campaigns.json
@@ -158,7 +158,7 @@
       {
         "pool": {
           "symbols": ["FUEL", "USDC"],
-          "id": "0x1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82-0x286c479da40dc953bddc3bb4c453b608bba2e0ac483b077bd475174115395e6b-false",
+          "id": "1d5d97005e41cae2187a895fd8eab0506111e0e2f3331cd3912c15c24e3c1d82-286c479da40dc953bddc3bb4c453b608bba2e0ac483b077bd475174115395e6b-false",
           "lpToken": "0x725f6c22fa2bc2e7fd2bb1c3e6887ac52d3a8586aabcb586733175eab9870384"
         },
         "rewards": [

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -117,12 +117,16 @@ export const getBoostReward = (
     };
     rewards: {
       dailyAmount: number;
+      assetId: string;
     }[];
   }[],
-): number => {
+): {
+  dailyAmount: number;
+  assetId: string | undefined;
+} => {
   const item = data.find((item) => item.pool.id === poolKey.replace(/0x/g, ""));
 
-  return item?.rewards[0].dailyAmount || 0;
+  return item?.rewards[0] || {dailyAmount: 0, assetId: undefined};
 };
 
 export const getRewardsPoolsId = (


### PR DESCRIPTION
Two minor issues with campaign info caused the wrong pools to register as having points, and the points from just the first campaign to show up.