### PR TITLE
perf: trim unnecessary keys from GraphQL response for pools data (PoolsConnection)

### DIFF
--- a/libs/web/src/hooks/usePoolsData.ts
+++ b/libs/web/src/hooks/usePoolsData.ts
@@ -60,44 +60,22 @@ export const usePoolsData = () => {
     query PoolsConnection($first: Int!, $after: String, $orderBy: [PoolOrderByInput!]!, $poolWhereInput: PoolWhereInput) {
       poolsConnection(first: $first, after: $after, orderBy: $orderBy, where: $poolWhereInput ) {
         totalCount
-        pageInfo {
-            hasNextPage
-            hasPreviousPage
-            startCursor
-            endCursor
-        }
         totalCount
         edges {
             node {
               id
-              isStable
-              reserve0
-              reserve1
               reserve0Decimal
               reserve1Decimal
-              volumeAsset0
-              volumeAsset1
               tvlUSD
-              lpToken {
-                symbol
-                name
-              }
               asset1 {
                 id
                 symbol
-                decimals
               }
               asset0 {
                 id
                 symbol
-                decimals
               }
               snapshots(where: { timestamp_gt: ${timestamp24hAgo} }) {
-                timestamp
-                volumeAsset0
-                volumeAsset1
-                volumeAsset0Decimal
-                volumeAsset1Decimal
                 volumeUSD
                 feesUSD
               }


### PR DESCRIPTION
Closes [MIR-139](https://wtconsulting.atlassian.net/browse/MIR-139)

- [x] Removed duplicate/ redundant data returned from PoolsConnection graphql query  