### PR TITLE
fix(web): swaps failing due to max fee `100000` instead of `242955`

### DIFF
--- a/libs/web/src/utils/constants.ts
+++ b/libs/web/src/utils/constants.ts
@@ -16,7 +16,7 @@ export const FUEL_ASSET_ID =
 
 export const DefaultTxParams: TxParams = {
   gasLimit: 2_000_000,
-  maxFee: 100_000,
+  maxFee: 275_000,
 } as const;
 
 export const MaxDeadline = 4_294_967_295 as const;


### PR DESCRIPTION
| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/721588f2-1aaf-4ce5-8d4a-4926a189ffaa) | ![image](https://github.com/user-attachments/assets/27ac8fab-13ae-4540-a7b4-80331937e36a) |