### PR TITLE
fix(widget): use dark mode for swap component in swaylend widget rendering 

### DIFF
--- a/apps/web/app/(periphery)/widget/layout.tsx
+++ b/apps/web/app/(periphery)/widget/layout.tsx
@@ -20,7 +20,7 @@ const inter = Inter({
 
 export default function Layout({children}: {readonly children: ReactNode}) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <head>
         <link rel="preload" as="image" href="/images/loader.webp" />
       </head>

--- a/apps/web/app/(periphery)/widget/page.tsx
+++ b/apps/web/app/(periphery)/widget/page.tsx
@@ -2,7 +2,7 @@ import Swap from "@/src/components/common/Swap/Swap";
 
 export default function Page() {
   return (
-    <div className="flex w-full max-w-lg mx-auto">
+    <div className="flex justify-center items-center w-full h-full max-w-lg mx-auto">
       <Swap isWidget />
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enabled dark mode styling across the application by adding a dark theme class to the root HTML element.
  - Improved layout by centering the Swap widget both vertically and horizontally within its container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->