### PR TITLE
fix(ui/web/reserve-item): dollar value formatting lacking comma separators

### DIFF
--- a/libs/web/src/components/pages/view-position-page/components/PositionView/ReserveItem/ReserveItem.tsx
+++ b/libs/web/src/components/pages/view-position-page/components/PositionView/ReserveItem/ReserveItem.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {CoinWithAmount} from "@/src/components/common";
 import {useFormattedReserveValue} from "./useFormattedReserveValue";
 import {Loader} from "@/src/components/common";
+import {formatNumber} from "@/src/utils/formatMoney";
 
 interface ReserveItemsProps {
   assetId: string;
@@ -19,13 +20,13 @@ const ReserveItem = ({assetId, amount, reserve}: ReserveItemsProps) => {
   return (
     <div className="flex items-center justify-between">
       <CoinWithAmount assetId={assetId} amount={coinAmount} withName />
-      {usdValue && reserve ? (
-        <div className="flex flex-col items-end">
+      {usdValue && reserve !== undefined ? (
+        <div className="flex flex-col items-end gap-y-2">
           <p className="font-medium text-[18px] leading-[21px]">
-            {Number(reserve?.toFixed(2)).toLocaleString()}
+            {formatNumber(reserve)}
           </p>
           <p className="opacity-64 font-normal text-[15px] leading-[18px]">
-            ${usdValue === "NaN" ? "~0" : usdValue}
+            {usdValue === "NaN" ? "~0" : usdValue}
           </p>
         </div>
       ) : (

--- a/libs/web/src/components/pages/view-position-page/components/PositionView/ReserveItem/useFormattedReserveValue.ts
+++ b/libs/web/src/components/pages/view-position-page/components/PositionView/ReserveItem/useFormattedReserveValue.ts
@@ -1,17 +1,17 @@
 import {useAssetPriceFromIndexer} from "@/src/hooks/useAssetPriceFromIndexer";
 import {formatDisplayAmount} from "@/src/utils/common";
+import {formatMoney} from "@/src/utils/formatMoney";
 
 export const useFormattedReserveValue = (
   assetId: string,
   amount: string,
   reserve: number | undefined,
 ) => {
-  const {price} = useAssetPriceFromIndexer(assetId);
-  const usdPrice = parseFloat(price.toFixed(2));
+  const {price: usdPrice} = useAssetPriceFromIndexer(assetId);
 
-  const valueOfAsset = usdPrice && reserve ? usdPrice * reserve : 0;
+  const valueOfAsset = reserve ? usdPrice * reserve : 0;
 
-  const usdValue = valueOfAsset.toFixed(2);
+  const usdValue = formatMoney(valueOfAsset);
 
   return {
     usdValue,

--- a/libs/web/src/utils/formatMoney.ts
+++ b/libs/web/src/utils/formatMoney.ts
@@ -1,0 +1,16 @@
+export const formatMoney = (amount: number) => {
+  const formatter = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+  });
+  return formatter.format(amount);
+};
+
+export const formatNumber = (value: number): string => {
+  const truncated = Math.floor(value * 100) / 100;
+
+  return new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(truncated);
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced consistent and localized formatting for monetary and numeric values throughout the app.

- **Refactor**
  - Improved the display of reserve and USD values for better clarity and consistency.
  - Enhanced validation logic for displaying reserve amounts.

- **Style**
  - Adjusted spacing in the reserve value section for improved visual layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->