### PR TITLE
Re-enable light mode as part of the rebrand

### DIFF
--- a/apps/web/app/(core)/layout.tsx
+++ b/apps/web/app/(core)/layout.tsx
@@ -1,6 +1,6 @@
 import {ReactNode} from "react";
 import {clsx} from "clsx";
-import {Prompt, Inter} from "next/font/google";
+import {Prompt, Inter, JetBrains_Mono} from "next/font/google";
 
 import {metadata} from "./metadata";
 
@@ -24,6 +24,11 @@ const inter = Inter({
   variable: "--font-inter",
 });
 
+const jetBrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains-mono",
+});
+
 export {metadata};
 
 export default function Layout({children}: {readonly children: ReactNode}) {
@@ -34,7 +39,7 @@ export default function Layout({children}: {readonly children: ReactNode}) {
       <head>
         <link rel="preload" as="image" href="/images/loader.webp" />
       </head>
-      <body className={clsx(inter.className, inter.variable, prompt.variable)}>
+      <body className={clsx(inter.className, inter.variable, prompt.variable, jetBrainsMono.variable)}>
         <Providers>
           <div className="flex flex-col min-h-screen relative">
             <FeatureGuard fallback={<Header />}>

--- a/apps/web/app/(core)/layout.tsx
+++ b/apps/web/app/(core)/layout.tsx
@@ -30,12 +30,7 @@ export default function Layout({children}: {readonly children: ReactNode}) {
   const glitchScavengerHuntEnabled = useAnimationStore.getState().masterEnabled;
 
   return (
-    <html
-      lang="en"
-      className="dark"
-      suppressHydrationWarning
-      style={{colorScheme: "dark"}}
-    >
+    <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         <link rel="preload" as="image" href="/images/loader.webp" />
       </head>

--- a/apps/web/app/(core)/liquidity/add/add-liquidity-page.tsx
+++ b/apps/web/app/(core)/liquidity/add/add-liquidity-page.tsx
@@ -18,11 +18,8 @@ import {
 } from "@/src/components/common";
 import {useModal} from "@/src/hooks";
 
-import {
-  /* DefaultSlippageValue, */
-  SlippageMode,
-} from "@/src/components/common/Swap/Swap";
-/* import { SettingsModalContentNew } from "@/src/components/common/Swap/components/SettingsModalContent/SettingsModalContentNew"; */
+import {SlippageMode} from "@/src/components/common/Swap/Swap";
+import SettingsModalContentNew from "@/src/components/common/settings-modal-content-new";
 
 export default function AddLiquidityPage() {
   const router = useRouter();
@@ -112,13 +109,13 @@ export default function AddLiquidityPage() {
           </SettingsModal>
         }
       >
-        {/* <SettingsModal title="Slippage tolerance">
+        <SettingsModal title="Slippage tolerance">
           <SettingsModalContentNew
             slippage={slippage}
             setSlippage={setSlippage}
             closeModal={closeSettingsModal}
           />
-        </SettingsModal> */}
+        </SettingsModal>
       </FeatureGuard>
     </main>
   );

--- a/apps/web/app/(core)/page.tsx
+++ b/apps/web/app/(core)/page.tsx
@@ -1,11 +1,64 @@
+"use client";
 import {Swap} from "@/src/components/common/Swap/Swap";
+import {useIsConnected} from "@fuels/react";
+
+const SVGComponent = (props) => (
+  <svg
+    width={800}
+    height={300}
+    viewBox="0 0 800 300"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <defs>
+      <radialGradient
+        id="grad-green"
+        cx={0.5}
+        cy={0.5}
+        r={0.5}
+        gradientUnits="objectBoundingBox"
+      >
+        <stop offset="0%" stopColor="#7EEAC0" stopOpacity={1} />
+        <stop offset="80%" stopColor="#7EEAC0" stopOpacity={0} />
+      </radialGradient>
+      <radialGradient
+        id="grad-red"
+        cx={0.5}
+        cy={0.5}
+        r={0.5}
+        gradientUnits="objectBoundingBox"
+      >
+        <stop offset="0%" stopColor="#FF7A7A" stopOpacity={1} />
+        <stop offset="80%" stopColor="#FF7A7A" stopOpacity={0} />
+      </radialGradient>
+      <radialGradient
+        id="grad-blue"
+        cx={0.5}
+        cy={0.5}
+        r={0.5}
+        gradientUnits="objectBoundingBox"
+      >
+        <stop offset="0%" stopColor="#93AFFF" stopOpacity={1} />
+        <stop offset="80%" stopColor="#93AFFF" stopOpacity={0} />
+      </radialGradient>
+    </defs>
+    <circle cx={250} cy={150} r={200} fill="url(#grad-green)" />
+    <circle cx={400} cy={150} r={200} fill="url(#grad-red)" />
+    <circle cx={550} cy={150} r={200} fill="url(#grad-blue)" />
+  </svg>
+);
 
 export default function Page() {
+  const {isConnected} = useIsConnected();
   return (
     <div className="flex flex-1 flex-col items-center w-full md:justify-center">
-      <div className="w-full max-w-lg px-4">
+      <div className="w-full max-w-lg px-4 relative">
         <Swap />
+        {isConnected && (
+          <SVGComponent className="absolute w-[650px] -bottom-25 -left-18 -z-1" />
+        )}
       </div>
     </div>
   );
 }
+``;

--- a/libs/web/src/components/common/Footer/Footer.tsx
+++ b/libs/web/src/components/common/Footer/Footer.tsx
@@ -2,13 +2,14 @@ import {Logo} from "@/src/components/common";
 import {BlogLink, DiscordLink, XLink} from "@/src/utils/constants";
 import {DiscordIcon, XSocialIcon, GithubIcon} from "@/meshwave-ui/icons";
 import {Button} from "@/meshwave-ui/Button";
+import {ModeToggle} from "@/src/components/common/toggle-mode";
 
 export default function Footer() {
   return (
-    <footer className="flex flex-col border-t border-white/10 box-border w-full py-4 px-4 max-w-6xl mx-auto gap-6">
+    <footer className="flex flex-col border-t border-white/10 box-border w-full py-4 px-4 max-w-6xl mx-auto">
       <div className="flex flex-col gap-4 lg:flex-row lg:justify-between lg:items-center lg:gap-[134px]">
         <Logo isFooter />
-        <div className="flex flex-col gap-3 text-base leading-[22px] text-content-tertiary font-normal lg:flex-row lg:justify-between lg:w-[650px] lg:text-lg lg:leading-6">
+        <div className="flex gap-3 text-base leading-[22px] text-content-tertiary font-normal lg:w-[650px] lg:text-lg lg:leading-6">
           <Button
             asChild
             variant="link"
@@ -56,6 +57,7 @@ export default function Footer() {
             </a>
           </Button>
         </div>
+        <ModeToggle />
         <div className="flex gap-3 lg:gap-4">
           <Button asChild variant="link" className="p-0 hover:opacity-65">
             <a href="https://github.com/mira-amm" target="_blank">

--- a/libs/web/src/components/common/connect-wallet-new.tsx
+++ b/libs/web/src/components/common/connect-wallet-new.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import {useWeb3Connection, useFormattedAddress} from "@/src/hooks";
 import {useEffect, useRef, useState} from "react";
-import { TransactionsHistory } from "./TransactionsHistory/TransactionsHistory";
+import {TransactionsHistory} from "./TransactionsHistory/TransactionsHistory";
 import {FuelAppUrl} from "@/src/utils/constants";
 import {openNewTab} from "@/src/utils/common";
 import {CopyNotification} from "./copy-notification";
@@ -73,7 +73,7 @@ export function ConnectWalletNew() {
           <div className="flex gap-x-3 p-3 rounded-[10px] justify-between bg-background-grey-dark dark:bg-background-grey-dark">
             <div className="">
               <div className="flex justify-between items-center mb-0.5">
-                <span>Power</span>
+                <span className="text-xs">Power</span>
                 <div className="h-2 w-5 bg-accent-primary-2"></div>
               </div>
               <Button
@@ -85,7 +85,7 @@ export function ConnectWalletNew() {
                 Connect
               </Button>
             </div>
-            <div className="bg-black rounded-[10px] text-accent-primary uppercase px-3 tracking-tight flex justify-center items-center text-sm">
+            <div className="w-[239.82px] bg-black rounded-[10px] font-(family-name:--font-jetbrains-mono) text-accent-primary uppercase px-3 tracking-tight flex justify-left items-center text-sm">
               No wallet connected
             </div>
           </div>
@@ -96,13 +96,13 @@ export function ConnectWalletNew() {
           <div className="flex gap-x-3 p-3 rounded-[10px] justify-between bg-background-grey-dark dark:bg-background-grey-dark">
             <div className="">
               <div className="flex justify-between items-center mb-0.5">
-                <span>Power</span>
-                <div className="h-2 w-5 bg-accent-primary"></div>
+                <span className="text-xs">Power</span>
+                <div className="h-2 w-5 bg-accent-primary shadow-[0_0_10px_#01ec97,0_0_20px_#01ec97aa]"></div>
               </div>
               <Button
                 onClick={disconnect}
                 size="xs"
-                className="rounded uppercase px-4 text-black"
+                className="bg-[#F95465] rounded uppercase px-4 text-black"
                 variant="destructive"
               >
                 Disconnect
@@ -110,7 +110,7 @@ export function ConnectWalletNew() {
             </div>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <div className="bg-black rounded-[10px] text-accent-primary uppercase px-3 tracking-tight flex justify-center items-center text-sm">
+                <div className="bg-black rounded-[10px] w-[239.82px] text-accent-primary font-(family-name:--font-jetbrains-mono) uppercase px-3 tracking-tight flex justify-between items-center text-sm">
                   {formattedAddress}
                   <ChevronDown className="text-content-dimmed-dark" />
                 </div>

--- a/libs/web/src/components/common/currency-box.tsx
+++ b/libs/web/src/components/common/currency-box.tsx
@@ -1,21 +1,14 @@
-import {
-  memo,
-  ChangeEvent,
-  useCallback
-} from "react";
+import {memo, ChangeEvent, useCallback} from "react";
 
 import {clsx} from "clsx";
 import {B256Address, BN} from "fuels";
 import {ChevronDown} from "lucide-react";
 
-import {
-  Coin,
-  TextButton
-} from "@/src/components/common";
+import {Coin, FeatureGuard, TextButton} from "@/src/components/common";
 
 import {CurrencyBoxMode} from "@/src/components/common/Swap/Swap";
 import {MinEthValueBN} from "@/src/utils/constants";
-import {useAssetMetadata} from "@/src/hooks";
+import {useAssetMetadata, useIsRebrandEnabled} from "@/src/hooks";
 import fiatValueFormatter from "@/src/utils/abbreviateNumber";
 
 export function CurrencyBox({
@@ -79,6 +72,8 @@ export function CurrencyBox({
       ? fiatValueFormatter(numericValue * usdRate!)
       : null;
 
+  const rebrandEnabled = useIsRebrandEnabled();
+
   return (
     <div
       className={clsx(
@@ -101,7 +96,10 @@ export function CurrencyBox({
           <input
             className={clsx(
               "flex-1 w-0 font-semibold text-[20px] leading-6 border-none bg-transparent outline-none",
-              "text-content-secondary dark:text-content-secondary font-inter",
+              "text-content-secondary dark:text-content-secondary ",
+              rebrandEnabled
+                ? "font-(family-name:--font-jetbrains-mono)"
+                : "font-inter",
               loading && "text-gray-400/40 dark:text-content-tertiary/40",
             )}
             type="text"

--- a/libs/web/src/components/common/header-new.tsx
+++ b/libs/web/src/components/common/header-new.tsx
@@ -2,7 +2,7 @@
 
 import {useEffect, useState, useCallback, useMemo} from "react";
 import Link from "next/link";
-import { usePathname} from "next/navigation"
+import {usePathname} from "next/navigation";
 
 import {Logo} from "@/src/components/common";
 import {useIsConnected} from "@fuels/react";
@@ -16,7 +16,6 @@ import {
 import {IconButton} from "@/src/components/common";
 import {PointsIcon} from "@/meshwave-ui/icons";
 import {X} from "lucide-react";
-import {ModeToggle} from "./toggle-mode";
 import {cn} from "@/src/utils/cn";
 import {ConnectWalletNew} from "./connect-wallet-new";
 
@@ -135,7 +134,6 @@ export function HeaderNew({
         </nav>
 
         <div className="flex items-center flex-1 justify-end gap-2">
-          <ModeToggle />
           <div className="hidden lg:flex">
             <ConnectWalletNew />
           </div>

--- a/libs/web/src/components/common/logo.tsx
+++ b/libs/web/src/components/common/logo.tsx
@@ -3,7 +3,7 @@ import {LogoIcon} from "@/meshwave-ui/icons";
 import {FeatureGuard} from "./feature-guard";
 import {LogoNew} from "./logo-new";
 
-export function Logo() {
+export function Logo({isFooter = false}: {isFooter?: boolean}) {
   return (
     <FeatureGuard
       fallback={
@@ -15,7 +15,7 @@ export function Logo() {
         </Link>
       }
     >
-      <LogoNew />
+      <LogoNew isFooter={isFooter} />
     </FeatureGuard>
   );
 }

--- a/libs/web/src/components/common/settings-modal-content-new.tsx
+++ b/libs/web/src/components/common/settings-modal-content-new.tsx
@@ -1,0 +1,114 @@
+import {
+  ChangeEvent,
+  Dispatch,
+  memo,
+  SetStateAction,
+  useState,
+  KeyboardEvent,
+  FocusEvent,
+  useRef,
+} from "react";
+import {clsx} from "clsx";
+import {useAnimationStore} from "@/src/stores/useGlitchScavengerHunt";
+
+const AutoSlippageValues = [10, 50, 100];
+
+function SettingsModalContentNew({
+  slippage,
+  setSlippage,
+  closeModal,
+}: {
+  slippage: number;
+  setSlippage: Dispatch<SetStateAction<number>>;
+  closeModal: VoidFunction;
+}) {
+  const [inputValue, setInputValue] = useState(`${slippage / 100}%`);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSlippageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value.replace("%", "");
+    setInputValue(value + "%");
+    useAnimationStore.getState().handleMagicInput(value);
+  };
+
+  const handleInputBlur = (event: FocusEvent<HTMLInputElement>) => {
+    const value = event.target.value.replace("%", "");
+    const numericValue = parseFloat(value.replace(",", ".").trim());
+    if (
+      isNaN(numericValue) ||
+      numericValue <= 0 ||
+      numericValue >= 100 ||
+      !Number.isFinite(numericValue)
+    ) {
+      setSlippage(100);
+      setInputValue(`${100 / 100}%`);
+      return;
+    }
+    setSlippage(Math.floor(Number((numericValue * 100).toFixed(2))));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Backspace") {
+      let value = inputValue.replace("%", "");
+      if (value.length === 0) return;
+      value = value.slice(0, -1);
+      setInputValue(value + "%");
+      if (value.length > 0) {
+        useAnimationStore.getState().handleMagicInput(value);
+      }
+      event.preventDefault();
+    }
+    if (event.key === "Enter") {
+      inputRef.current?.blur();
+    }
+  };
+
+  const handleSlippageButtonClick = (value: number) => {
+    setSlippage(value);
+    closeModal();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <p className="text-content-tertiary dark:text-content-dimmed-light">
+          The amount the price can change unfavorably before the trade reverts
+        </p>
+      </div>
+
+      <div className="flex gap-2 items-center">
+        <div className="flex flex-1">
+          {AutoSlippageValues.map((value) => (
+            <button
+              key={value}
+              className={clsx(
+                "w-full px-3 py-[14px] first:rounded-l-lg last:rounded-r-lg text-content-dimmed-light border bg-background-grey-dark hover:border dark:hover:text-content-primary hover:border-accent-primary dark:hover:border-accent-primary hover:border-black",
+                slippage === value &&
+                  "dark:border-accent-primary border border-content-tertiary bg-black dark:bg-background-grey-dark text-white",
+              )}
+              onClick={() => handleSlippageButtonClick(value)}
+            >
+              {value / 100}%
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center justify-center">
+          <div className="flex justify-center items-center px-3">or</div>
+          <input
+            type="text"
+            inputMode="decimal"
+            pattern="^[0-9]*[.,]?[0-9]*$"
+            className="w-22 px-3 py-[14px] rounded-lg text-content-dimmed-light bg-background-grey-dark focus:border-accent-primary focus:text-content-primary"
+            value={inputValue}
+            onChange={handleSlippageChange}
+            onKeyDown={handleKeyDown}
+            onBlur={handleInputBlur}
+            ref={inputRef}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default memo(SettingsModalContentNew);

--- a/libs/web/src/components/common/slippage-setting.tsx
+++ b/libs/web/src/components/common/slippage-setting.tsx
@@ -11,7 +11,7 @@ export function SlippageSetting({
   return (
     <>
       <p className="px-2 py-1 text-[13px] leading-4 font-normal rounded-lg bg-background-grey-light dark:bg-background-grey-light text-content-dimmed-light dark:text-content-dimmed-light">
-        {slippage / 100}% slippage
+        {slippage / 100}% Slippage
       </p>
       <IconButton
         onClick={openSettingsModal}

--- a/libs/web/src/components/common/swap-success-modal.tsx
+++ b/libs/web/src/components/common/swap-success-modal.tsx
@@ -23,7 +23,7 @@ export function SwapSuccessModal({
       <p className="font-medium text-[22px] leading-[26px] text-center">
         Swap success
       </p>
-      <p className="text-[14px] leading-[16px] text-content-dimmed-dark text-center">
+      <p className="text-[14px] leading-[16px] text-content-tertiary dark:text-content-dimmed-dark text-center">
         {subText}
       </p>
       <Link

--- a/libs/web/src/core/providers/Providers.tsx
+++ b/libs/web/src/core/providers/Providers.tsx
@@ -60,9 +60,8 @@ export function Providers({children}: {children: ReactNode}) {
           <DisclaimerWrapper>
             <ThemeProvider
               attribute="class"
-              defaultTheme="dark"
-              forcedTheme="dark"
-              enableSystem={false}
+              defaultTheme="system"
+              enableSystem
               disableTransitionOnChange
             >
               {children}

--- a/libs/web/styles.css
+++ b/libs/web/styles.css
@@ -52,18 +52,6 @@
 }
 
 @layer base {
-  /* Ensure dark mode styles are always applied */
-  * {
-    color-scheme: dark;
-  }
-
-  /* Override any light mode preferences */
-  @media (prefers-color-scheme: light) {
-    :root {
-      color-scheme: dark;
-    }
-  }
-
   :root {
     --page-background: #fdfdfd;
     --background-primary: #0e111e;


### PR DESCRIPTION
This reverts commit e8cd88afee023af1c7586d8ecf9d85ef0c56f794.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now automatically adapts its theme (light or dark) based on your system preferences, instead of always using dark mode.
  * Added a new slippage tolerance settings modal for easier customization of trade settings.
  * Introduced a dynamic background graphic visible when connected to enhance visual feedback.

* **Style**
  * Removed forced dark mode styling for a more flexible and personalized appearance.
  * Updated fonts by adding JetBrains Mono for improved readability in inputs and wallet displays.
  * Enhanced wallet connection UI with refined styling and clearer button states.
  * Adjusted footer layout to include a mode toggle switch for quick theme changes.
  * Improved swap success modal text colors for better visibility in light and dark themes.

* **Bug Fixes**
  * Fixed typo in swap preview status message for clarity.

* **Refactor**
  * Simplified imports and cleaned up commented code for better maintainability.
  * Removed mode toggle from the header to streamline the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->