### PR TITLE
fix: MIR-304 resolve asset switch glitch reset

### DIFF
--- a/libs/web/src/components/common/Swap/Swap.tsx
+++ b/libs/web/src/components/common/Swap/Swap.tsx
@@ -346,7 +346,10 @@ export function Swap({isWidget}: {isWidget?: boolean}) {
     setActiveMode("sell");
     if (!isWidget) {
       setSwapCoins(({sell, buy}) => ({sell: buy, buy: sell}));
-      useAnimationStore.getState().handleMagicTripleClickToken();
+      // Delay the glitch effect to ensure it captures the updated state
+      setTimeout(() => {
+        useAnimationStore.getState().handleMagicTripleClickToken();
+      }, 0);
     }
   }, [isWidget, setSwapCoins]);
 


### PR DESCRIPTION
After the glitch was triggered text inside of the swap was reset to what it was prior to switch #3
This resulted in the incorrect text for both the asset name balance

Resolves Mir-302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the timing of the glitch animation effect to ensure it starts after the DOM is fully updated, resulting in smoother visual transitions.
  * Adjusted the timing of the glitch animation trigger during asset swaps for more consistent behavior.

* **Style**
  * Enhanced code formatting and readability in the asset swap interface without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Before
<img width="456" height="353" alt="image" src="https://github.com/user-attachments/assets/e3f29641-26ce-4ac0-870c-34d2ded3bf07" />

## After
<img width="692" height="541" alt="image" src="https://github.com/user-attachments/assets/e377ba1f-683d-4c28-801a-24d6d163e0a1" />
