### PR TITLE
build: disable pnpm install on all devenv reloads

### DIFF
--- a/apps/microvisor/languages/javascript.nix
+++ b/apps/microvisor/languages/javascript.nix
@@ -11,7 +11,7 @@
       # };
       pnpm = {
         enable = true;
-        install.enable = true;
+        # install.enable = true;
       };
     };
   };


### PR DESCRIPTION
## Summary

Disable the auto pnpm install on all devenv reloading.

This was causing far too many 5-10second delays on each branch switch or change that could effect pnpm inputs. 

## Checklist

### 🧪 Tests & Quality

- [x] All tests pass locally (`npx vitest`)

### ⚙️ Build & Tooling

- [x] Project starts successfully using `pnpm dev` or `pnpm start` (verifies build, dependencies,
      and runtime)
- [x] Ran `pnpm fix:formatting` to ensure consistent code style
- [x] No obvious runtime or import errors (manual verification if needed)

### 🔍 Miscellaneous

- [x] No unrelated changes are included in this PR
- [x] Follows project conventions and folder structure

