### PR TITLE
fix: Enable light mode support in Storybook for meshwave Button

### DIFF
--- a/apps/design/.storybook/preview.tsx
+++ b/apps/design/.storybook/preview.tsx
@@ -18,6 +18,7 @@ import {
   lightUIStorybook,
 } from "./themes-storybook-ui";
 import "../../../libs/meshwave-ui/global.css";
+import "../../../libs/web/styles.css";
 
 const preview: Preview = {
   parameters: {


### PR DESCRIPTION
## Summary
Fixed light mode display for the meshwave Button component in Storybook by importing the web app's color system.

## Problem
The meshwave Button component was not displaying correctly in Storybook's light mode because it was missing the Mira color system definitions (like `--accent-primary`, `--old-mira-text`, etc.) that the Button component depends on.

## Solution
Added import of `libs/web/styles.css` to Storybook's preview configuration so the Button component has access to the complete Mira color system for both light and dark modes.

## Changes
- **Storybook Config**: Added `import "../../../libs/web/styles.css";` to `apps/design/.storybook/preview.tsx`

## Test Plan
- [ ] Verify meshwave Button component displays correctly in Storybook light mode
- [ ] Confirm Button variants (default, outline, secondary, etc.) render properly
- [ ] Test theme switching between light and dark modes works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Storybook to include additional global styles for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->