### PR TITLE
fix: standardize border radius with semantic Tailwind classes

### DIFF
--- a/libs/meshwave-ui/Button/Button.tsx
+++ b/libs/meshwave-ui/Button/Button.tsx
@@ -4,7 +4,7 @@ import {Slot} from "@radix-ui/react-slot";
 import {cva, type VariantProps} from "class-variance-authority";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[10px] text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -21,9 +21,9 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-[10px] px-3 text-xs",
-        xs: "h-7 rounded-[10px] px-3 text-xs",
-        lg: "h-10 rounded-[10px] px-8",
+        sm: "h-8 rounded-lg px-3 text-xs",
+        xs: "h-7 rounded-lg px-3 text-xs",
+        lg: "h-10 rounded-lg px-8",
         icon: "h-9 w-9",
         xl: "h-11",
         "2xl": "py-4",

--- a/libs/web/src/components/common/AprBadge/AprBadge.tsx
+++ b/libs/web/src/components/common/AprBadge/AprBadge.tsx
@@ -76,7 +76,7 @@ export function AprBadge({
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
         className={cn(
-          "relative flex items-center gap-[5px] rounded-[10px] cursor-pointer",
+          "relative flex items-center gap-[5px] rounded-lg cursor-pointer",
           "justify-center",
           small
             ? "min-w-[76px] py-[5px] px-[8px]"
@@ -108,7 +108,7 @@ export function AprBadge({
         {isHovered && (
           <div
             onClick={() => setIsHovered(false)}
-            className="absolute top-[140%] left-0 z-[9999] w-[292px] rounded-[10px] p-[25px] text-white text-left shadow-[0_4px_10px_rgba(0,0,0,0.1)] bg-[linear-gradient(170deg,#262f5f_35%,#c41cff_100%)] flex flex-col gap-[10px]"
+            className="absolute top-[140%] left-0 z-[9999] w-[292px] rounded-lg p-[25px] text-white text-left shadow-[0_4px_10px_rgba(0,0,0,0.1)] bg-[linear-gradient(170deg,#262f5f_35%,#c41cff_100%)] flex flex-col gap-[10px]"
             style={{left: leftAlignValue ?? "0"}}
           >
             <AprLabel

--- a/libs/web/src/components/common/Swap/Swap.tsx
+++ b/libs/web/src/components/common/Swap/Swap.tsx
@@ -113,7 +113,7 @@ const PreviewSummary = memo(function PreviewSummary({
   previewPrice: number | undefined;
 }) {
   return (
-    <div className="flex bg-background-primary dark:bg-background-secondary p-4 rounded-[10px] flex-col gap-2 text-accent-primary font-alt dark:text-content-tertiary leading-[16px]">
+    <div className="flex bg-background-primary dark:bg-background-secondary p-4 rounded-lg flex-col gap-2 text-accent-primary font-alt dark:text-content-tertiary leading-[16px]">
       <div className="flex justify-between">
         <p className="text-sm">Rate:</p>
         {previewLoading || tradeState === TradeState.REFETCHING ? (
@@ -678,7 +678,7 @@ export function Swap({isWidget}: {isWidget?: boolean}) {
 
         <div
           className={cn(
-            "flex flex-col gap-4 p-4 pb-[18px] rounded-[10px] bg-background-grey-dark border-border-secondary border-[12px] dark:border-0 dark:bg-background-grey-dark",
+            "flex flex-col gap-4 p-4 pb-[18px] rounded-2xl bg-background-grey-dark border-border-secondary border-[12px] dark:border-0 dark:bg-background-grey-dark",
             swapPending && "z-[5]"
           )}
         >

--- a/libs/web/src/components/common/TransactionsHistory/TransactionsHistory.tsx
+++ b/libs/web/src/components/common/TransactionsHistory/TransactionsHistory.tsx
@@ -70,7 +70,7 @@ export const TransactionsHistory = forwardRef<
           className={`flex flex-col gap-5 p-3 ${
             isRebrandEnabled
               ? "rounded-xl bg-gradient-to-br from-accent-primary/10 to-accent-primary/5 border border-accent-primary/20"
-              : "rounded-[10px] bg-gradient-to-br from-[#663e92] to-[#29294e]"
+              : "rounded-lg bg-gradient-to-br from-[#663e92] to-[#29294e]"
           }`}
         >
           <div className="flex items-center gap-2.5">

--- a/libs/web/src/components/common/connect-wallet-new.tsx
+++ b/libs/web/src/components/common/connect-wallet-new.tsx
@@ -77,7 +77,7 @@ export function ConnectWalletNew() {
   return (
     <>
       {!isConnected && (
-        <div className="rounded-[10px] border-border-secondary border-[12px] dark:border-0">
+        <div className="rounded-lg border-border-secondary border-[12px] dark:border-0">
           <div className="flex gap-x-3 p-3 justify-between bg-background-grey-dark dark:bg-background-grey-dark">
             <div className="">
               <div className="flex justify-between items-center mb-0.5">
@@ -93,7 +93,7 @@ export function ConnectWalletNew() {
                 Connect
               </Button>
             </div>
-            <div className="w-[239.82px] bg-black rounded-[10px] font-alt text-accent-primary uppercase px-3 tracking-tight flex justify-left items-center text-sm">
+            <div className="w-[239.82px] bg-black rounded-lg font-alt text-accent-primary uppercase px-3 tracking-tight flex justify-left items-center text-sm">
               No wallet connected
             </div>
           </div>
@@ -101,7 +101,7 @@ export function ConnectWalletNew() {
       )}
       {isConnected && (
         <div ref={containerRef} className="relative w-[410px]">
-          <div className="rounded-[10px] border-[12px] border-border-secondary dark:border-0">
+          <div className="rounded-lg border-[12px] border-border-secondary dark:border-0">
             <div className="flex gap-x-3 p-3 justify-between bg-background-grey-dark dark:bg-background-grey-dark">
               <div>
                 <div className="flex justify-between items-center mb-0.5">
@@ -134,7 +134,7 @@ export function ConnectWalletNew() {
           </div>
 
           {open && (
-            <div className="absolute left-0 mt-2 w-full border-[12px] border-border-secondary dark:border-0 bg-background-grey-dark dark:bg-[#262834] px-2 py-2.5 rounded-[10px] z-50">
+            <div className="absolute left-0 mt-2 w-full border-[12px] border-border-secondary dark:border-0 bg-background-grey-dark dark:bg-[#262834] px-2 py-2.5 rounded-lg z-50">
               <div
                 onClick={() => {
                   handleCopy();

--- a/libs/web/src/components/common/copy-notification.tsx
+++ b/libs/web/src/components/common/copy-notification.tsx
@@ -11,7 +11,7 @@ export const CopyNotification: React.FC<{
       className={`
         bg-content-positive
         w-[480px]
-        rounded-[10px]
+        rounded-lg
         flex justify-between items-center
         px-[20px] py-[16px]
         absolute z-[1000]

--- a/libs/web/src/components/common/currency-box.tsx
+++ b/libs/web/src/components/common/currency-box.tsx
@@ -78,7 +78,7 @@ export function CurrencyBox({
   return (
     <div
       className={cn(
-        "flex flex-col gap-2.5 rounded-[10px] border border-transparent bg-background-tertiary dark:bg-background-secondary px-3 py-3 lg:px-4",
+        "flex flex-col gap-2.5 rounded-lg border border-transparent bg-background-tertiary dark:bg-background-secondary px-3 py-3 lg:px-4",
         className,
         isRebrandEnabled
           ? "focus-within:border-black"

--- a/libs/web/src/components/common/dropdown-menu.tsx
+++ b/libs/web/src/components/common/dropdown-menu.tsx
@@ -18,8 +18,8 @@ export const DropDownMenu = forwardRef<
     <ul
       ref={ref}
       className={clsx(
-        "absolute top-[50px] right-[-5px] z-20 max-w-[205px] p-[10px] rounded-[12px] bg-white dark:bg-[#262834] flex flex-col box-border",
-        "max-[1023px]:fixed max-[1023px]:top-auto max-[1023px]:left-0 max-[1023px]:right-0 max-[1023px]:bottom-0 max-[1023px]:w-full max-[1023px]:max-w-full max-[1023px]:rounded-t-[12px] max-[1023px]:pt-[38px]"
+        "absolute top-[50px] right-[-5px] z-20 max-w-[205px] p-[10px] rounded-xl bg-white dark:bg-[#262834] flex flex-col box-border",
+        "max-[1023px]:fixed max-[1023px]:top-auto max-[1023px]:left-0 max-[1023px]:right-0 max-[1023px]:bottom-0 max-[1023px]:w-full max-[1023px]:max-w-full max-[1023px]:rounded-t-xl max-[1023px]:pt-[38px]"
       )}
     >
       {buttons.map((button) => (

--- a/libs/web/src/components/common/steps-icon.tsx
+++ b/libs/web/src/components/common/steps-icon.tsx
@@ -3,7 +3,7 @@ export const StepsIcon: React.FC<{
 }> = ({icon}) => {
   return (
     <div
-      className="flex flex-col justify-center items-center w-16 h-16 rounded-[10px]"
+      className="flex flex-col justify-center items-center w-16 h-16 rounded-lg"
       style={{
         background:
           "linear-gradient(132.04deg, #262f5f 11.87%, #c41cff 176.88%)",

--- a/libs/web/src/components/pages/add-liquidity-page/components/CoinInput/CoinInput.tsx
+++ b/libs/web/src/components/pages/add-liquidity-page/components/CoinInput/CoinInput.tsx
@@ -54,7 +54,7 @@ const CoinInput = ({
       : null;
 
   return (
-    <div className="min-h-[65px] flex items-center gap-1 p-3 rounded-[10px] bg-background-secondary">
+    <div className="min-h-[65px] flex items-center gap-1 p-3 rounded-lg bg-background-secondary">
       <div className="flex flex-col gap-1 items-start flex-1">
         <input
           type="text"

--- a/libs/web/src/components/pages/create-pool-page/components/CreatePool/CreatePoolDialog.tsx
+++ b/libs/web/src/components/pages/create-pool-page/components/CreatePool/CreatePoolDialog.tsx
@@ -313,7 +313,7 @@ export function CreatePoolDialog({
       </div>
 
       {poolExists && (
-        <div className="flex items-center gap-2 p-3 rounded-[10px] bg-gradient-to-r from-[#5872fc] via-[#6142ba] to-[#c41cff]">
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-gradient-to-r from-[#5872fc] via-[#6142ba] to-[#c41cff]">
           <div className="w-5 h-5 flex items-center justify-center rounded-full bg-content-dimmed-dark">
             <Sparkle className="size-3" />
           </div>

--- a/libs/web/src/components/pages/liquidity-page/components/Boosts/BoostsBanner/BoostsBanner.tsx
+++ b/libs/web/src/components/pages/liquidity-page/components/Boosts/BoostsBanner/BoostsBanner.tsx
@@ -6,7 +6,7 @@ import {BrandText} from "@/src/components/common";
 
 export function BoostsBanner() {
   return (
-    <div className="flex flex-col justify-between gap-2.5 p-4 rounded-[10px] bg-[url('/images/pointsGradientBackground.png')]">
+    <div className="flex flex-col justify-between gap-2.5 p-4 rounded-lg bg-[url('/images/pointsGradientBackground.png')]">
       <PointsIcon />
       <h2 className="text-white">Introducing Points</h2>
       <div className="flex flex-wrap justify-between items-start gap-3">

--- a/libs/web/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
+++ b/libs/web/src/components/pages/liquidity-page/components/Boosts/BoostsRewards/BoostsRewards.tsx
@@ -39,7 +39,7 @@ export function BoostsRewards() {
 
       <div
         className={clsx(
-          "flex justify-between items-center gap-4 rounded-[10px] min-h-[110px] bg-primary-900 bg-[url('/images/pointsGradientBackground.png')] bg-cover bg-center p-6"
+          "flex justify-between items-center gap-4 rounded-lg min-h-[110px] bg-primary-900 bg-[url('/images/pointsGradientBackground.png')] bg-cover bg-center p-6"
         )}
       >
         <div className="flex flex-col gap-2">

--- a/libs/web/src/components/pages/view-position-page/components/PositionView/desktop-position-view.tsx
+++ b/libs/web/src/components/pages/view-position-page/components/PositionView/desktop-position-view.tsx
@@ -65,7 +65,7 @@ export function DesktopPositionView({
 
       <div className="flex gap-3 w-full">
         <MiraBlock pool={pool} />
-        <div className="flex flex-col min-w-[350px] flex-1 w-full rounded-[10px] bg-background-grey-dark border-border-secondary border-[12px] dark:border-0 dark:bg-background-grey-dark">
+        <div className="flex flex-col min-w-[350px] flex-1 w-full rounded-lg bg-background-grey-dark border-border-secondary border-[12px] dark:border-0 dark:bg-background-grey-dark">
           <div className="flex flex-col gap-[15px] p-4">
             <p className="text-[16px] leading-[19px]">Your position</p>
             <AprDisplay pool={pool} />
@@ -83,7 +83,7 @@ export function DesktopPositionView({
         </div>
       </div>
 
-      <div className="w-full p-4 rounded-[12px] flex flex-col gap-4 bg-background-grey-dark border-border-secondary border-[12px] dark:border-0 dark:bg-background-grey-dark">
+      <div className="w-full p-4 rounded-xl flex flex-col gap-4 bg-background-grey-dark border-border-secondary border-[12px] dark:border-0 dark:bg-background-grey-dark">
         <p className="text-[16px] font-semibold leading-[19px] border-b border-content-grey-dark/40 pb-3">
           Pool reserves
         </p>

--- a/libs/web/src/hooks/useIsRebrandEnabled.ts
+++ b/libs/web/src/hooks/useIsRebrandEnabled.ts
@@ -1,4 +1,3 @@
 export function useIsRebrandEnabled() {
-  return true;
-  // return process.env.NEXT_PUBLIC_ENABLE_REBRAND_UI === "true";
+  return process.env.NEXT_PUBLIC_ENABLE_REBRAND_UI === "true";
 }

--- a/libs/web/src/hooks/useIsRebrandEnabled.ts
+++ b/libs/web/src/hooks/useIsRebrandEnabled.ts
@@ -1,3 +1,4 @@
 export function useIsRebrandEnabled() {
-  return process.env.NEXT_PUBLIC_ENABLE_REBRAND_UI === "true";
+  return true;
+  // return process.env.NEXT_PUBLIC_ENABLE_REBRAND_UI === "true";
 }

--- a/libs/web/src/hooks/useModal.tsx
+++ b/libs/web/src/hooks/useModal.tsx
@@ -71,7 +71,7 @@ export function useModal(): [ReturnType, () => void, () => void] {
             <div
               className={clsx(
                 "fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-20",
-                "flex flex-col gap-4 p-4 bg-white dark:bg-[#262834] rounded-[12px] w-[90%] max-h-[80%] overflow-auto",
+                "flex flex-col gap-4 p-4 bg-white dark:bg-[#262834] rounded-xl w-[90%] max-h-[80%] overflow-auto",
                 "lg:max-w-[460px]",
                 "border-border-secondary border-[12px] dark:border-0",
                 className


### PR DESCRIPTION
## Summary
- Changed swap main container from `rounded-[10px]` to `rounded-2xl` (16px)
- Replaced all `rounded-[12px]` with `rounded-xl` (12px) 
- Replaced all `rounded-[10px]` with `rounded-lg` (8px)
- Standardized border radius across entire application using Tailwind semantic classes

## Test plan
- [ ] Verify swap component uses consistent border radius with rest of app
- [ ] Check all major containers use semantic Tailwind radius classes
- [ ] Ensure visual consistency across all components

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated border-radius styles across multiple components to use standardized Tailwind CSS classes (`rounded-lg`, `rounded-xl`, `rounded-2xl`) instead of fixed pixel values. This change affects the appearance of buttons, badges, modals, dropdowns, and various UI containers, resulting in more consistent and maintainable corner rounding throughout the application. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->