### PR TITLE
fix: Prevent leading zeros in swap inputs while preserving typing flow

### DIFF
--- a/libs/web/src/components/common/Swap/Swap.tsx
+++ b/libs/web/src/components/common/Swap/Swap.tsx
@@ -30,7 +30,7 @@ import {
   triggerClassAnimation,
 } from "@/src/components/common";
 
-import {createPoolKey, openNewTab} from "@/src/utils/common";
+import {createPoolKey, openNewTab, cleanNumberString} from "@/src/utils/common";
 
 import {PriceImpactNew} from "@/src/components/common/Swap/components/price-impact";
 
@@ -284,9 +284,10 @@ export function Swap({isWidget}: {isWidget?: boolean}) {
     ) {
       return "";
     }
-    return activeMode === "sell"
+    const rawValue = activeMode === "sell"
       ? trade.amountOut.formatUnits(decimals)
       : trade.amountIn.formatUnits(decimals);
+    return cleanNumberString(rawValue);
   }, [trade, tradeState, activeMode, decimals]);
 
   useEffect(() => {

--- a/libs/web/src/utils/common.ts
+++ b/libs/web/src/utils/common.ts
@@ -3,6 +3,45 @@ import {B256Address} from "fuels";
 import {buildPoolId, PoolId} from "mira-dex-ts";
 import {DefaultLocale} from "./constants";
 
+export const cleanNumberString = (value: string, preserveTyping: boolean = false): string => {
+  if (!value || value === "") return "";
+  
+  // If preserving typing flow, be less aggressive
+  if (preserveTyping) {
+    // Only remove excessive leading zeros (keep one zero before decimal)
+    let cleaned = value.replace(/^0+(?=\d)/, "");
+    
+    // If it starts with a decimal point, add a leading zero
+    if (cleaned.startsWith(".")) {
+      cleaned = "0" + cleaned;
+    }
+    
+    // Don't remove trailing zeros during typing (user might be typing more digits)
+    return cleaned;
+  }
+  
+  // For display/final formatting, be more aggressive
+  if (value === "0") return "";
+  
+  // Remove leading zeros but keep at least one digit before decimal
+  let cleaned = value.replace(/^0+(?=\d)/, "");
+  
+  // If it starts with a decimal point, add a leading zero
+  if (cleaned.startsWith(".")) {
+    cleaned = "0" + cleaned;
+  }
+  
+  // Remove trailing zeros after decimal point
+  if (cleaned.includes(".")) {
+    cleaned = cleaned.replace(/\.?0+$/, "");
+  }
+  
+  // If we end up with just "0." or empty, return empty string
+  if (cleaned === "0." || cleaned === "") return "";
+  
+  return cleaned;
+};
+
 export const openNewTab = (url: string) => {
   window.open(url, "_blank");
 };


### PR DESCRIPTION
## Summary
- Fixes issue where leading zeros appeared in swap number inputs  
- Preserves natural typing flow (allows "0" → "." → "1" sequence)
- Cleans number formatting consistently across swap interface

## Changes
- **Added `cleanNumberString` utility** in `common.ts` with typing-aware modes
- **Updated Swap component** to clean `formatUnits` output in preview calculations
- **Updated CurrencyBox component** to:
  - Clean balance displays from `formatUnits`
  - Preserve user input during typing (no cleaning on `onChange`)
  - Apply cleaning on `onBlur` for final clean values

## Behavior
- **During typing**: No interference with user input flow
- **After typing**: Clean formatting removes unnecessary leading/trailing zeros  
- **Programmatic values**: Always cleaned (balances, calculated amounts)

## Test plan
- [ ] Verify typing "0.1" sequence works properly
- [ ] Check that balance displays don't show leading zeros
- [ ] Confirm swap preview amounts are cleanly formatted
- [ ] Test various decimal input scenarios (0.001, 00.5, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved input handling for numeric fields by introducing automatic cleaning and normalization of number strings in relevant components.
  * Added a utility to ensure consistent formatting of numeric values across the interface.

* **Bug Fixes**
  * Enhanced accuracy and display of numeric inputs, reducing issues with leading/trailing zeros and formatting inconsistencies when entering or displaying amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->