### PR TITLE
fix swap resetting issue

### DIFF
--- a/libs/web/src/components/common/Swap/Swap.tsx
+++ b/libs/web/src/components/common/Swap/Swap.tsx
@@ -501,8 +501,12 @@ export function Swap({isWidget}: {isWidget?: boolean}) {
       if (txCostData?.tx) {
         const result = await triggerSwap(txCostData.tx);
         if (result) {
-          setSwapState(initialSwapState);
-          setInputsState(initialInputsState);
+          // Preserve current asset selection, only clear amounts
+          setSwapState((prev) => ({
+            sell: {...prev.sell, amount: ""},
+            buy: {...prev.buy, amount: ""},
+          }));
+          setInputsState({sell: {amount: ""}, buy: {amount: ""}});
           setReview(false);
           openSuccess();
           triggerClassAnimation("dino");
@@ -530,8 +534,6 @@ export function Swap({isWidget}: {isWidget?: boolean}) {
     openSuccess,
     openFailure,
     refetchBalances,
-    initialSwapState,
-    initialInputsState,
     fetchCost,
   ]);
 


### PR DESCRIPTION
## Summary

<!-- Briefly describe the purpose of this PR and what it changes. -->

## Checklist

### 🧪 Tests & Quality

- [ ] Added unit or integration tests for new functionality (using [Vitest](https://vitest.dev/))
- [x] All tests pass locally (`npx vitest`)

### ⚙️ Build & Tooling

- [x] Project starts successfully using `pnpm dev` or `pnpm start` (verifies build, dependencies,
      and runtime)
- [x] Ran `pnpm nx format:all` to ensure consistent code style
- [x] No obvious runtime or import errors (manual verification if needed)

### 🎨 UI (if applicable)

- [ ] Storybook stories are added or updated (`pnpm storybook`)
- [ ] Accessibility has been considered (e.g. labels, roles, focus management)
- [ ] UI changes have been manually verified and screenshots are attached (if relevant)

### 🔍 Miscellaneous

- [x] No unrelated changes are included in this PR
- [ ] Breaking changes are clearly documented, with migration steps if needed
- [x] Follows project conventions and folder structure

## Additional Note


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap behavior to retain selected assets after a successful transaction, while only clearing the entered amounts. Asset selections will no longer reset unexpectedly after swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->