### PR TITLE
ci: Prevent duplicate workflow runs on PR updates

### DIFF
--- a/.github/workflows/TEST.yaml
+++ b/.github/workflows/TEST.yaml
@@ -3,9 +3,9 @@ name: 🧪 Unit & E2E Tests
 
 on:
   push:
-    branches: ["*"]
+    branches: ['main']
   pull_request:
-    branches: ["*"]
+    branches: ['*']
 
 jobs:
   e2e:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: 🧹 Lint
 
 on:
   push:
-    branches: ['*']
+    branches: ['main']
   pull_request:
     branches: ['*']
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 
 on:
   push:
-    branches: '*'
+    branches:
+      - 'main'
   pull_request:
     branches: '*'
 


### PR DESCRIPTION
Previously we would run CI on all branch pushes and all PR updates, this means duplicate running on all PR updates, which is a waste of resources

## Summary

<!-- Briefly describe the purpose of this PR and what it changes. -->

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://docs.microchain.systems/libraries/contributing/installation).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] I've added tests to cover my changes (if applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly.
- [x] No unrelated changes are included in this PR
- [x] Breaking changes are clearly documented, with migration steps if needed

## Additional Notes
