### PR TITLE
test(apps/web): expect subsquid latest block height to be delayed

### DIFF
--- a/apps/web/app/api/latest-block/route.test.ts
+++ b/apps/web/app/api/latest-block/route.test.ts
@@ -3,7 +3,12 @@ import {NextRequest} from "next/server";
 import {GET} from "./route";
 
 describe("GET /api/latest-block (integration)", () => {
-  it("returns a valid block number and a recent timestamp", async () => {
+  /**
+   * This test is expected to fail while the subsquid indexer is lagging behind so far.
+   * If it suddenly passes, that means the indexer is back online
+   * and we should remove `test.fails` so it becomes a normal test again.
+   */
+  it.fails("returns a valid block number and a recent timestamp", async () => {
     const req = new NextRequest("http://localhost/api/latest-block");
     const res = await GET(req);
 


### PR DESCRIPTION
## Summary

Updated the subsquid blockheight test to expect-to-fail due to current issues with subsquid's delayed indexing. This allows the rest of CI to run without making a change in status of this test invisible (skip, or todo)

The subsquid issue can be seen in MIR-472.

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://docs.microchain.systems/libraries/contributing/installation).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [x] My change requires documentation updates.
- [ ] I've updated the documentation accordingly.
- [ ] No unrelated changes are included in this PR
- [x] Breaking changes are clearly documented, with migration steps if needed

## Additional Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an integration test to be expected-to-fail by default to reflect current external service availability, reducing false negatives in CI.
* **Documentation**
  * Added a note explaining the temporary test expectation and when it should pass again.
  * 
No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->