### PR TITLE
perf(apps/web): MIR-472 Change to subsquid indexer v4

### DIFF
--- a/apps/web/app/api/latest-block/route.test.ts
+++ b/apps/web/app/api/latest-block/route.test.ts
@@ -3,12 +3,7 @@ import {NextRequest} from "next/server";
 import {GET} from "./route";
 
 describe("GET /api/latest-block (integration)", () => {
-  /**
-   * This test is expected to fail while the subsquid indexer is lagging behind so far.
-   * If it suddenly passes, that means the indexer is back online
-   * and we should remove `test.fails` so it becomes a normal test again.
-   */
-  it.fails("returns a valid block number and a recent timestamp", async () => {
+  it("returns a valid block number and a recent timestamp", async () => {
     const req = new NextRequest("http://localhost/api/latest-block");
     const res = await GET(req);
 

--- a/apps/web/app/api/pair/route.test.ts
+++ b/apps/web/app/api/pair/route.test.ts
@@ -32,7 +32,7 @@ import {fetchPoolById, createPairFromPool, GET} from "./route";
 const mockRequest = vi.mocked(request);
 const mockGql = vi.mocked(gql);
 
-const INDEXER_URL = "https://mira-dex.squids.live/mira-indexer@v3/api/graphql";
+const INDEXER_URL = "https://mira-dex.squids.live/mira-indexer@v4/api/graphql";
 
 const poolId = "pool-xyz";
 const rawPool = {

--- a/libs/swap/src/domains.ts
+++ b/libs/swap/src/domains.ts
@@ -2,7 +2,7 @@ export const DOMAINS = [
   "https://mainnet-explorer.fuel.network",
   "https://explorer-indexer-mainnet.fuel.network",
   "https://verified-assets.fuel.network",
-  "https://mira-dex.squids.live/mira-indexer@v3/api/graphql",
+  "https://mira-dex.squids.live/mira-indexer@v4/api/graphql",
   "https://firebasestorage.googleapis.com",
   "https://github.com",
   "https://img.icons8.com",

--- a/libs/web/src/utils/constants.ts
+++ b/libs/web/src/utils/constants.ts
@@ -33,7 +33,7 @@ export const ValidNetworkChainId = CHAIN_IDS.fuel.mainnet;
 export const NetworkUrl: string = "https://mainnet.fuel.network/v1/graphql";
 
 export const SQDIndexerUrl =
-  "https://mira-dex.squids.live/mira-indexer@v3/api/graphql" as const;
+  "https://mira-dex.squids.live/mira-indexer@v4/api/graphql" as const;
 export const MainnetUrl = "https://mainnet-explorer.fuel.network";
 export const ApiBaseUrl = "https://prod.api.microchain.systems" as const;
 


### PR DESCRIPTION
This new version of the indexer has smaller stride lengths and resolves
the performance issues involved with block latency on V3.

Changes:
- Change url to point to the new indexer version
- Re-enable the block number test, expect to pass rather than expect to
fail

## Summary

<!-- Briefly describe the purpose of this PR and what it changes. -->

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://docs.microchain.systems/libraries/contributing/installation).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [x] I've added tests to cover my changes (if applicable).
- [x] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly.
- [x] No unrelated changes are included in this PR
- [x] Breaking changes are clearly documented, with migration steps if needed

## Additional Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the indexer API to v4 to improve reliability and compatibility of data queries used by the app (affects pool data and latest block endpoints).

* **Tests**
  * Updated tests to target the new indexer API endpoint.
  * Converted a previously expected-failing latest-block test into a standard passing test to reflect current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->