### PR TITLE
fix(api): mir-446 coingecko integration

### DIFF
--- a/apps/web/app/api/events/route.test.ts
+++ b/apps/web/app/api/events/route.test.ts
@@ -41,6 +41,7 @@ describe("GET /api/events", () => {
     const mockActions = {
       actions: [
         {
+          id: "action1",
           pool: {id: "pool1"},
           asset0: {id: "asset0", decimals: 6},
           asset1: {id: "asset1", decimals: 9},
@@ -57,6 +58,7 @@ describe("GET /api/events", () => {
           blockNumber: 1,
         },
         {
+          id: "action2",
           pool: {id: "pool2"},
           asset0: {id: "asset0", decimals: 9},
           asset1: {id: "asset1", decimals: 9},
@@ -106,7 +108,7 @@ describe("GET /api/events", () => {
           eventType: "swap",
           asset0In: "0.000000300",
           asset1Out: "0.000001001",
-          priceNative: 0.29970029970029965,
+          priceNative: 3.336666666666667, // asset1Out / asset0In = 0.000001001 / 0.000000300
         },
       ],
     });
@@ -115,6 +117,57 @@ describe("GET /api/events", () => {
       url: SQDIndexerUrl,
       document: "dummy_query",
       variables: {fromBlock: 100, toBlock: 200},
+    });
+  });
+
+  it("should handle V2 liquidity events", async () => {
+    const req = new NextRequest(
+      "http://localhost:3000/api/events/?fromBlock=10&toBlock=20"
+    );
+
+    const mockActions = {
+      actions: [
+        {
+          id: "action-v2",
+          pool: {id: "pool-v2"},
+          asset0: {id: "asset0", decimals: 9},
+          asset1: {id: "asset1", decimals: 6},
+          amount1Out: "0",
+          amount1In: "1000",
+          amount0Out: "0",
+          amount0In: "500",
+          reserves0After: "5000",
+          reserves1After: "10000",
+          type: "ADD_LIQUIDITY_V2",
+          transaction: "txn-v2",
+          recipient: "recipient-v2",
+          timestamp: 111111,
+          blockNumber: 12,
+        },
+      ],
+    };
+
+    mockRequest.mockResolvedValueOnce(mockActions);
+
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json).toEqual({
+      events: [
+        {
+          block: {blockNumber: 12, blockTimestamp: 111111},
+          txnId: "txn-v2",
+          txnIndex: 0,
+          eventIndex: 0,
+          maker: "recipient-v2",
+          pairId: "pool-v2",
+          reserves: {asset0: "0.000005000", asset1: "0.010000"},
+          eventType: "join",
+          amount0: "0.000000500",
+          amount1: "0.001000",
+        },
+      ],
     });
   });
 
@@ -142,5 +195,93 @@ describe("GET /api/events", () => {
     expect(await res.json()).toEqual({
       error: "Failed to fetch events data",
     });
+  });
+
+  it("should properly index transactions and events within a block", async () => {
+    const req = new NextRequest(
+      "http://localhost:3000/api/events/?fromBlock=100&toBlock=200"
+    );
+
+    const mockActions = {
+      actions: [
+        // Block 1, Transaction 1, Event 1
+        {
+          id: "action1",
+          pool: {id: "pool1"},
+          asset0: {id: "asset0", decimals: 9},
+          asset1: {id: "asset1", decimals: 9},
+          amount1Out: "1000",
+          amount1In: "0",
+          amount0Out: "0",
+          amount0In: "500",
+          reserves0After: "1000",
+          reserves1After: "2000",
+          type: "SWAP",
+          transaction: "txn1",
+          recipient: "recipient1",
+          timestamp: 1234567890,
+          blockNumber: 1,
+        },
+        // Block 1, Transaction 1, Event 2
+        {
+          id: "action2",
+          pool: {id: "pool2"},
+          asset0: {id: "asset0", decimals: 9},
+          asset1: {id: "asset1", decimals: 9},
+          amount1Out: "2000",
+          amount1In: "0",
+          amount0Out: "0",
+          amount0In: "600",
+          reserves0After: "1500",
+          reserves1After: "3000",
+          type: "SWAP",
+          transaction: "txn1",
+          recipient: "recipient1",
+          timestamp: 1234567890,
+          blockNumber: 1,
+        },
+        // Block 1, Transaction 2, Event 1
+        {
+          id: "action3",
+          pool: {id: "pool3"},
+          asset0: {id: "asset0", decimals: 9},
+          asset1: {id: "asset1", decimals: 9},
+          amount1Out: "3000",
+          amount1In: "0",
+          amount0Out: "0",
+          amount0In: "700",
+          reserves0After: "2000",
+          reserves1After: "4000",
+          type: "SWAP",
+          transaction: "txn2",
+          recipient: "recipient2",
+          timestamp: 1234567890,
+          blockNumber: 1,
+        },
+      ],
+    };
+
+    mockRequest.mockResolvedValueOnce(mockActions);
+
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json.events).toHaveLength(3);
+    
+    // Verify first event in first transaction
+    expect(json.events[0].txnIndex).toBe(0);
+    expect(json.events[0].eventIndex).toBe(0);
+    expect(json.events[0].txnId).toBe("txn1");
+
+    // Verify second event in first transaction
+    expect(json.events[1].txnIndex).toBe(0);
+    expect(json.events[1].eventIndex).toBe(1);
+    expect(json.events[1].txnId).toBe("txn1");
+
+    // Verify first event in second transaction
+    expect(json.events[2].txnIndex).toBe(1);
+    expect(json.events[2].eventIndex).toBe(0);
+    expect(json.events[2].txnId).toBe("txn2");
   });
 });

--- a/apps/web/app/api/events/route.ts
+++ b/apps/web/app/api/events/route.ts
@@ -16,9 +16,15 @@ import {formatUnits} from "fuels";
 
 const MAX_BLOCK_RANGE = 5000;
 
+type GeckoEvent = GeckoTerminalQueryResponses.EventsResponse["events"][number];
+
 const ACTIONS_QUERY = gql`
   query GetActions($fromBlock: Int!, $toBlock: Int!) {
-    actions(where: {blockNumber_gt: $fromBlock, blockNumber_lt: $toBlock}) {
+    actions(
+      where: {blockNumber_gte: $fromBlock, blockNumber_lte: $toBlock}
+      orderBy: [blockNumber_ASC, transaction_ASC, id_ASC]
+    ) {
+      id
       pool {
         id
       }
@@ -53,18 +59,36 @@ async function fetchActions(fromBlock: number, toBlock: number) {
   });
 }
 
+function isSwapType(type: SQDIndexerResponses.Action["type"]) {
+  return (
+    type === SQDIndexerTypes.ActionTypes.SWAP ||
+    type === SQDIndexerTypes.ActionTypes.SWAP_V2
+  );
+}
+
+function isJoinType(type: SQDIndexerResponses.Action["type"]) {
+  return (
+    type === SQDIndexerTypes.ActionTypes.JOIN ||
+    type === SQDIndexerTypes.ActionTypes.JOIN_V2
+  );
+}
+
+function isExitType(type: SQDIndexerResponses.Action["type"]) {
+  return (
+    type === SQDIndexerTypes.ActionTypes.EXIT ||
+    type === SQDIndexerTypes.ActionTypes.EXIT_V2
+  );
+}
+
 function formatAmount(value: string, decimals: number): string {
   return formatUnits(value || "0", decimals);
 }
 
-function createEventData(action: SQDIndexerResponses.Action):
-  | (
-      | GeckoTerminalQueryResponses.SwapEvent
-      | (GeckoTerminalQueryResponses.JoinExitEvent & {
-          block: GeckoTerminalQueryResponses.Block;
-        })
-    )
-  | null {
+function createEventData(
+  action: SQDIndexerResponses.Action,
+  txnIndex: number,
+  eventIndex: number
+): GeckoEvent | null {
   const {
     asset0,
     asset1,
@@ -82,7 +106,7 @@ function createEventData(action: SQDIndexerResponses.Action):
     asset1: formatAmount(action.reserves1After, asset1.decimals),
   };
 
-  if (type === SQDIndexerTypes.ActionTypes.SWAP) {
+  if (isSwapType(type)) {
     const amount0In = action.amount0In;
     const amount1Out = action.amount1Out;
     const amount1In = action.amount1In;
@@ -91,8 +115,8 @@ function createEventData(action: SQDIndexerResponses.Action):
     const eventBase = {
       eventType: "swap" as const,
       txnId: transaction,
-      txnIndex: 0,
-      eventIndex: 0,
+      txnIndex,
+      eventIndex,
       maker: recipient,
       pairId: pool.id,
       reserves,
@@ -102,17 +126,19 @@ function createEventData(action: SQDIndexerResponses.Action):
     if (amount0In && amount1Out) {
       const formatted0In = formatAmount(amount0In, asset0.decimals);
       const formatted1Out = formatAmount(amount1Out, asset1.decimals);
+      // priceNative = amount(asset1) / amount(asset0)
       return {
         ...eventBase,
         asset0In: formatted0In,
         asset1Out: formatted1Out,
-        priceNative: parseFloat(formatted0In) / parseFloat(formatted1Out),
+        priceNative: parseFloat(formatted1Out) / parseFloat(formatted0In),
       };
     }
 
     if (amount1In && amount0Out) {
       const formatted1In = formatAmount(amount1In, asset1.decimals);
       const formatted0Out = formatAmount(amount0Out, asset0.decimals);
+      // priceNative = amount(asset1) / amount(asset0)
       return {
         ...eventBase,
         asset1In: formatted1In,
@@ -124,23 +150,19 @@ function createEventData(action: SQDIndexerResponses.Action):
     return null;
   }
 
-  if (
-    type === SQDIndexerTypes.ActionTypes.JOIN ||
-    type === SQDIndexerTypes.ActionTypes.EXIT
-  ) {
+  if (isJoinType(type) || isExitType(type)) {
     const amount0 = action.amount0In || action.amount0Out;
     const amount1 = action.amount1In || action.amount1Out;
 
     if (!amount0 || !amount1) return null;
 
     return {
-      eventType:
-        type === SQDIndexerTypes.ActionTypes.JOIN
-          ? GeckoTerminalTypes.EventTypes.JOIN
-          : GeckoTerminalTypes.EventTypes.EXIT,
+      eventType: isJoinType(type)
+        ? GeckoTerminalTypes.EventTypes.JOIN
+        : GeckoTerminalTypes.EventTypes.EXIT,
       txnId: transaction,
-      txnIndex: 0,
-      eventIndex: 0,
+      txnIndex,
+      eventIndex,
       maker: recipient,
       pairId: pool.id,
       amount0: formatAmount(amount0, asset0.decimals),
@@ -159,24 +181,47 @@ export async function GET(req: NextRequest) {
     const fromBlock = parseInt(url.searchParams.get("fromBlock") || "0", 10);
     const toBlock = parseInt(url.searchParams.get("toBlock") || "0", 10);
 
-    if (!fromBlock || !toBlock || fromBlock >= toBlock) {
+    if (!fromBlock || !toBlock || fromBlock > toBlock) {
       return NextResponse.json(
         {error: "'fromBlock' and 'toBlock' must be valid and ordered"},
         {status: 400}
       );
     }
 
-    const events: GeckoTerminalQueryResponses.Event[] = [];
+    const events: GeckoEvent[] = [];
 
-    for (let start = fromBlock; start < toBlock; start += MAX_BLOCK_RANGE) {
-      const end = Math.min(start + MAX_BLOCK_RANGE, toBlock);
+    for (let start = fromBlock; start <= toBlock; start += MAX_BLOCK_RANGE) {
+      const end = Math.min(start + MAX_BLOCK_RANGE - 1, toBlock);
       const {actions} = await fetchActions(start, end);
 
+      // Track transaction and event indices
+      let currentBlock = 0;
+      let currentTxn = "";
+      let txnIndex = 0;
+      let eventIndex = 0;
+
       for (const action of actions) {
-        const eventData = createEventData(action);
+        // Reset indices when we move to a new block
+        if (action.blockNumber !== currentBlock) {
+          currentBlock = action.blockNumber;
+          currentTxn = "";
+          txnIndex = 0;
+          eventIndex = 0;
+        }
+
+        // Increment txnIndex when we encounter a new transaction
+        if (action.transaction !== currentTxn) {
+          if (currentTxn !== "") {
+            txnIndex++;
+          }
+          currentTxn = action.transaction;
+          eventIndex = 0;
+        }
+
+        const eventData = createEventData(action, txnIndex, eventIndex);
         if (eventData) {
-          const {block, ...rest} = eventData;
-          events.push({...rest, block});
+          events.push(eventData);
+          eventIndex++;
         }
       }
     }

--- a/apps/web/app/api/pair/route.test.ts
+++ b/apps/web/app/api/pair/route.test.ts
@@ -42,6 +42,9 @@ const rawPool = {
   creationBlock: 100,
   creationTime: 1_610_000_000,
   creationTx: "0xtx",
+  protocolVersion: 2,
+  binStepBps: 100,
+  baseFee: 500,
 };
 const expectedPair = {
   id: poolId,
@@ -51,6 +54,7 @@ const expectedPair = {
   createdAtBlockNumber: rawPool.creationBlock,
   createdAtBlockTimestamp: rawPool.creationTime,
   createdAtTxnId: rawPool.creationTx,
+  feeBps: 5, // (100 * 500) / 10000 = 5
 };
 
 beforeAll(() => {

--- a/apps/web/app/api/pair/route.ts
+++ b/apps/web/app/api/pair/route.ts
@@ -26,6 +26,9 @@ export const fetchPoolById = async (
         creationBlock
         creationTime
         creationTx
+        protocolVersion
+        binStepBps
+        baseFee
       }
     }
   `;
@@ -45,15 +48,31 @@ export const fetchPoolById = async (
 
 export const createPairFromPool = (
   pool: SQDIndexerResponses.Pool
-): GeckoTerminalQueryResponses.Pair => ({
-  id: pool.id,
-  dexKey: "mira",
-  asset0Id: pool.asset0.id,
-  asset1Id: pool.asset1.id,
-  createdAtBlockNumber: pool.creationBlock,
-  createdAtBlockTimestamp: pool.creationTime,
-  createdAtTxnId: pool.creationTx,
-});
+): GeckoTerminalQueryResponses.Pair => {
+  // Calculate feeBps based on protocol version
+  // V2 pools: fee = (binStepBps * baseFee) / 10000
+  // V1 pools: standard 0.3% fee (30 bps)
+  let feeBps: number | undefined;
+
+  if (pool.protocolVersion === 2 && pool.binStepBps && pool.baseFee) {
+    // For V2 pools, calculate the effective fee in basis points
+    feeBps = (pool.binStepBps * pool.baseFee) / 10000;
+  } else if (pool.protocolVersion === 1) {
+    // V1 pools have a standard 0.3% fee
+    feeBps = 30;
+  }
+
+  return {
+    id: pool.id,
+    dexKey: "mira",
+    asset0Id: pool.asset0.id,
+    asset1Id: pool.asset1.id,
+    createdAtBlockNumber: pool.creationBlock,
+    createdAtBlockTimestamp: pool.creationTime,
+    createdAtTxnId: pool.creationTx,
+    feeBps,
+  };
+};
 
 export async function GET(req: NextRequest) {
   try {

--- a/libs/web/shared/constants.ts
+++ b/libs/web/shared/constants.ts
@@ -1,8 +1,11 @@
 export namespace SQDIndexerTypes {
   export enum ActionTypes {
     JOIN = "ADD_LIQUIDITY",
+    JOIN_V2 = "ADD_LIQUIDITY_V2",
     EXIT = "REMOVE_LIQUIDITY",
+    EXIT_V2 = "REMOVE_LIQUIDITY_V2",
     SWAP = "SWAP",
+    SWAP_V2 = "SWAP_V2",
   }
 }
 

--- a/libs/web/shared/types.ts
+++ b/libs/web/shared/types.ts
@@ -19,6 +19,9 @@ export namespace SQDIndexerResponses {
     creationTx: string;
     creator?: string;
     feeBps?: number;
+    protocolVersion: number;
+    binStepBps?: number;
+    baseFee?: number;
     pool?: {
       id: string;
       name: string;
@@ -30,6 +33,7 @@ export namespace SQDIndexerResponses {
   }
 
   export interface Action {
+    id: string;
     pool: Pool;
     recipient: string;
     asset0: {
@@ -48,8 +52,11 @@ export namespace SQDIndexerResponses {
     reserves1After: string;
     type:
       | SQDIndexerTypes.ActionTypes.SWAP
+      | SQDIndexerTypes.ActionTypes.SWAP_V2
       | SQDIndexerTypes.ActionTypes.JOIN
-      | SQDIndexerTypes.ActionTypes.EXIT;
+      | SQDIndexerTypes.ActionTypes.JOIN_V2
+      | SQDIndexerTypes.ActionTypes.EXIT
+      | SQDIndexerTypes.ActionTypes.EXIT_V2;
     transaction: string;
     timestamp: number;
     blockNumber: number;


### PR DESCRIPTION
## Summary

### CoinGecko API Integration — Mira DEX (Fuel)

### Pair Endpoint
- Added **`feeBps`** to responses
- **V2 pools:** dynamic fee = `(binStepBps * baseFee) / 10_000`
- **V1 pools:** standard **30 bps (0.3%)**
- Updated GraphQL queries to fetch required fee fields

### Price Calculation
- Fixed **`priceNative`** to: `amount(asset1) / amount(asset0)`
- Previously (incorrect): `asset0 / asset1`

### Transaction & Event Indexing
- Sequential indexing of **transactions within blocks**
- Track **event order** within each transaction
- Ensure uniqueness via **`txnIndex + eventIndex`**
- GraphQL ordering: **`[blockNumber_ASC, transaction_ASC, id_ASC]`**

### Testing Instructions

Please follow the **Indexer Setup Guide** for full local setup:
See **INDEXER-SETUP-GUIDE** for detailed steps.

---

## 1. Query: Get Start Block

**Endpoint:**

```
http://localhost:3000/api/events/?fromBlock={from}&toBlock={to}
```

**GraphQL Query:**

```graphql
actions {
  id
  blockNumber
}
```

Use this to retrieve the first relevant `blockNumber` from the event stream.

---

## 2. Query: Get Pool ID

**Endpoint:**

```
http://localhost:3000/api/pair?id=pool_id
```

**GraphQL Query:**

```graphql
pools {
  id
}
```

Use this to fetch the `id` of the pool

---

<!-- Briefly describe the purpose of this PR and what it changes. -->

## Checklist

- [x] I've thoroughly read the latest [contribution guidelines](https://docs.microchain.systems/libraries/contributing/installation).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [x] My commit messages follow [conventional spec](https://www.conventionalcommits.org/en/)
- [ ] I've added tests to cover my changes (if applicable).
- [ ] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [ ] My change requires documentation updates.
- [ ] I've updated the documentation accordingly.
- [x] No unrelated changes are included in this PR
- [x] Breaking changes are clearly documented, with migration steps if needed

## Additional Notes
