### PR TITLE
fix(ci): add clear error when GH_TOKEN secret is missing/expired

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ jobs:
       - name: 📦 Install Packages
         run: pnpm install;
 
+      - name: 🔑 Verify GH_TOKEN secret is configured
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GH_TOKEN secret is not set or has expired. A GitHub PAT with 'repo' scope is required for NX releases. Please update the GH_TOKEN secret in Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
       - name: 📒 Dry Run Release
         if: github.ref_name != 'main'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::GH_TOKEN secret is not set or has expired. A GitHub PAT with 'repo' scope is required for NX releases. Please update the GH_TOKEN secret in Settings → Secrets and variables → Actions."
+            echo "::error::GH_TOKEN secret is not set. A GitHub PAT with 'repo' scope is required for NX releases. Please update the GH_TOKEN secret in Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token $GH_TOKEN" https://api.github.com/user)
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::GH_TOKEN is invalid or expired (HTTP $HTTP_STATUS). Please update the GH_TOKEN secret with a valid GitHub PAT with 'repo' scope in Settings → Secrets and variables → Actions."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Add a validation step to the release workflow that checks for the `GH_TOKEN` secret before attempting NX release operations
- Surfaces a clear `::error::` message directing maintainers to update the secret in repo settings

The release workflow has been failing on **every PR and push to main since Nov 2025** because the `GH_TOKEN` PAT expired. NX reports a generic "Unable to resolve data via the GitHub API" error which obscures the root cause. This change makes the failure reason immediately obvious.

**Note:** This PR does not fix the expired token itself — someone with repo admin access needs to generate a new PAT with `repo` scope and update the `GH_TOKEN` secret in Settings → Secrets and variables → Actions.

## Test plan
- [ ] Verify the release check now shows a clear error message about the missing/expired token
- [ ] After updating the `GH_TOKEN` secret, verify the release dry-run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-release validation to ensure the required release token is configured and valid.
  * If the token is missing, empty, invalid, or expired, the workflow now stops early with a clear error message to prevent faulty releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->